### PR TITLE
feature/game-logic-overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -481,3 +481,8 @@ $RECYCLE.BIN/
 *.env
 /bin/
 /obj/
+/.idea/.idea.Fate-Phantasm-BW-Ghost-touch.dir/.idea/.gitignore
+/.idea/.idea.Fate-Phantasm-BW-Ghost-touch.dir/.idea/AndroidProjectSystem.xml
+/.idea/.idea.Fate-Phantasm-BW-Ghost-touch.dir/.idea/encodings.xml
+/.idea/.idea.Fate-Phantasm-BW-Ghost-touch.dir/.idea/indexLayout.xml
+/.idea/.idea.Fate-Phantasm-BW-Ghost-touch.dir/.idea/vcs.xml

--- a/AutoMapperProfile.cs
+++ b/AutoMapperProfile.cs
@@ -47,6 +47,8 @@ namespace RPG_dotnet
 
             CreateMap<SessionCharacterState, GetSessionCharacterStateDto>()
                 .ForMember(dest => dest.characterName, opt => opt.MapFrom(src => src.character.name));
+
+            CreateMap<GameActionLog, GetGameActionLogDto>();
         }
     }
 }

--- a/Controllers/GameSessionController.cs
+++ b/Controllers/GameSessionController.cs
@@ -18,10 +18,7 @@ namespace RPG_dotnet.Controllers
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             var response = await _gameSessionService.CreateGameSessionAsync(userId, newSessionDto);
-
-            if (!response.success)
-                return BadRequest(response);
-
+            if (!response.success) return BadRequest(response);
             return Ok(response);
         }
 
@@ -29,63 +26,59 @@ namespace RPG_dotnet.Controllers
         public async Task<ActionResult<ServiceResponse<List<GetGameSessionDto>>>> GetActiveGameSessions()
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
-            var response = await _gameSessionService.GetActiveGameSessionsAsync(userId);
-            return Ok(response);
+            return Ok(await _gameSessionService.GetActiveGameSessionsAsync(userId));
         }
+
 
         [HttpGet("{sessionId}")]
         public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> GetGameSessionById(int sessionId)
         {
             var response = await _gameSessionService.GetGameSessionByIdAsync(sessionId);
-            if (response.data is null)
-                return NotFound(response);
+            if (response.data is null) return NotFound(response);
             return Ok(response);
         }
 
         [HttpGet]
-        public async Task<ActionResult<ServiceResponse<List<GetGameSessionDto>>>> GetGameSessionsByUserId(GameSessionState? state = null)
+        public async Task<ActionResult<ServiceResponse<List<GetGameSessionDto>>>> GetGameSessionsByUserId(
+            GameSessionState? state = null)
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
-            var response = await _gameSessionService.GetGameSessionsByUserIdAsync(userId, state);
-            return Ok(response);
+            return Ok(await _gameSessionService.GetGameSessionsByUserIdAsync(userId, state));
         }
 
         [HttpPut("move")]
-        public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> MoveCharacter(
-            MoveActionDto dto)
+        public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> MoveCharacter(MoveActionDto dto)
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             var response = await _gameSessionService.MoveCharacterAsync(userId, dto);
-
-            if (!response.success)
-                return BadRequest(response);
-
+            if (!response.success) return BadRequest(response);
             return Ok(response);
         }
 
         [HttpPut("attack")]
-        public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> AttackCharacter(
-            AttackCharacterDto dto)
+        public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> AttackCharacter(AttackCharacterDto dto)
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             var response = await _gameSessionService.AttackCharacterAsync(userId, dto);
-
-            if (!response.success)
-                return BadRequest(response);
-
+            if (!response.success) return BadRequest(response);
             return Ok(response);
         }
 
         [HttpPut("cast")]
-        public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> CastSpell(
-            CastSpellDto dto)
+        public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> CastSpell(CastSpellDto dto)
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             var response = await _gameSessionService.CastSpellAsync(userId, dto);
+            if (!response.success) return BadRequest(response);
+            return Ok(response);
+        }
 
-            if (!response.success)
-                return BadRequest(response);
-
+        [HttpPut("endturn")]
+        public async Task<ActionResult<ServiceResponse<GetGameSessionDto>>> EndTurn(EndTurnDto dto)
+        {
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+            var response = await _gameSessionService.EndTurnAsync(userId, dto);
+            if (!response.success) return BadRequest(response);
             return Ok(response);
         }
 
@@ -94,10 +87,7 @@ namespace RPG_dotnet.Controllers
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             var response = await _gameSessionService.AbandonSessionAsync(userId, sessionId);
-
-            if (!response.success)
-                return BadRequest(response);
-
+            if (!response.success) return BadRequest(response);
             return Ok(response);
         }
 
@@ -106,10 +96,7 @@ namespace RPG_dotnet.Controllers
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             var response = await _gameSessionService.AcceptSessionAsync(userId, dto);
-
-            if (!response.success)
-                return BadRequest(response);
-
+            if (!response.success) return BadRequest(response);
             return Ok(response);
         }
 
@@ -118,10 +105,7 @@ namespace RPG_dotnet.Controllers
         {
             var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             var response = await _gameSessionService.RejectSessionAsync(userId, sessionId);
-
-            if (!response.success)
-                return BadRequest(response);
-
+            if (!response.success) return BadRequest(response);
             return Ok(response);
         }
     }

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -24,7 +24,7 @@ namespace RPG_dotnet.Data
 
         public DbSet<GameSession> GameSessions { get; set; }
         public DbSet<SessionCharacterState> SessionCharacterStates { get; set; }
-
+        public DbSet<GameActionLog> GameActionLogs { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -107,6 +107,12 @@ namespace RPG_dotnet.Data
                 .WithMany()
                 .HasForeignKey(gs => gs.opponentUserId)
                 .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<GameActionLog>()
+                .HasOne(log => log.session)
+                .WithMany(gs => gs.actionLog)
+                .HasForeignKey(log => log.sessionId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
     }
 }

--- a/Dtos/GameSession/CastSpellDto.cs
+++ b/Dtos/GameSession/CastSpellDto.cs
@@ -2,11 +2,11 @@ namespace RPG_dotnet.Dtos.GameSession
 {
     public class CastSpellDto
     {
-        public int userId { get; set; }
         public int sessionId { get; set; }
         public int casterId { get; set; }
         public int targetId { get; set; }
         public int abilityId { get; set; }
     }
+
 
 }

--- a/Dtos/GameSession/EndTurnDto.cs
+++ b/Dtos/GameSession/EndTurnDto.cs
@@ -1,0 +1,6 @@
+namespace RPG_dotnet.Dtos.GameSession;
+
+public class EndTurnDto
+{
+    public int sessionId { get; set; }
+}

--- a/Dtos/GameSession/GetGameActionLogDto.cs
+++ b/Dtos/GameSession/GetGameActionLogDto.cs
@@ -1,0 +1,16 @@
+namespace RPG_dotnet.Dtos.GameSession;
+
+public class GetGameActionLogDto
+{
+    public int id { get; set; }
+    public int actorCharacterId { get; set; }
+    public int? targetCharacterId { get; set; }
+    public GameActionType actionType { get; set; }
+    public int? abilityId { get; set; }
+    public int damageDealt { get; set; }
+    public double manaSpent { get; set; }
+    public double manaGained { get; set; }
+    public float? newPosition { get; set; }
+    public int turnIndex { get; set; }
+    public DateTime timestamp { get; set; }
+}

--- a/Dtos/GameSession/GetGameSessionDto.cs
+++ b/Dtos/GameSession/GetGameSessionDto.cs
@@ -25,5 +25,7 @@ namespace RPG_dotnet.Dtos.GameSession
         public float maxPosition { get; set; }
 
         public List<GetSessionCharacterStateDto> participants { get; set; } = new();
+
+        public List<GetGameActionLogDto> actionLog { get; set; } = new();
     }
 }

--- a/Helpers/Functions.cs
+++ b/Helpers/Functions.cs
@@ -36,50 +36,55 @@ namespace RPG_dotnet.Helpers
 
         public static void AdvanceTurn(GameSession session)
         {
-            // Reset action flags if all alive participants have acted
-            if (session.participants.Where(p => p.isAlive).All(p => p.hasActedThisTurn))
+            var playerIds = session.participants
+                .Select(p => p.userId)
+                .Distinct()
+                .ToList();
+
+            if (playerIds.Count < 2) return;
+
+            int nextPlayerId = playerIds.First(id => id != session.currentTurnPlayerId);
+
+            // Reset the incoming player's characters for their turn
+            foreach (var p in session.participants.Where(p => p.userId == nextPlayerId && p.isAlive))
+                p.hasActedThisTurn = false;
+
+            // If all alive characters have now acted, it's a new full round
+            bool fullRoundComplete = session.participants
+                .Where(p => p.isAlive)
+                .All(p => p.hasActedThisTurn);
+
+            if (fullRoundComplete)
             {
-                foreach (var participant in session.participants.Where(p => p.isAlive))
-                {
-                    participant.hasActedThisTurn = false;
-                }
+                session.currentTurnIndex++;
+                foreach (var p in session.participants.Where(p => p.isAlive))
+                    p.hasActedThisTurn = false;
             }
 
-            // Move to next alive participant
-            int total = session.participants.Count;
-            for (int i = 1; i <= total; i++)
-            {
-                int nextIndex = (session.currentTurnIndex + i) % total;
-                if (session.participants[nextIndex].isAlive)
-                {
-                    session.currentTurnIndex = nextIndex;
-                    break;
-                }
-            }
+            session.currentTurnPlayerId = nextPlayerId;
         }
 
         public static void CheckVictoryCondition(GameSession session)
         {
-            var aliveUserIds = session.participants
+            var alivePlayerIds = session.participants
                 .Where(p => p.isAlive)
                 .Select(p => p.userId)
                 .Distinct()
                 .ToList();
 
-            if (aliveUserIds.Count <= 1)
+            if (alivePlayerIds.Count <= 1)
             {
                 session.state = GameSessionState.COMPLETED;
+                session.winnerUserId = alivePlayerIds.Count == 1 ? alivePlayerIds[0] : null;
             }
         }
 
         public static void EnsureUserTurn(GameSession session, int userId)
         {
-            var currentPlayer = session.participants.FirstOrDefault(p => p.user.id == session.currentTurnPlayerId) ?? throw new GenericException("Current turn player not found in session participants.", 422);
-            if (userId != currentPlayer.user.id)
-            {
+            if (session.currentTurnPlayerId != userId)
                 throw new GenericException("It is not your turn.", 422);
-            }
         }
+
         public static bool IsWithinProximity(float attackerX, float targetX, float allowedDistance = 10f)
         {
             return Math.Abs(attackerX - targetX) <= allowedDistance;

--- a/Migrations/20260511184045_AddGameLogicOverhaul.Designer.cs
+++ b/Migrations/20260511184045_AddGameLogicOverhaul.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using RPG_dotnet.Data;
 
@@ -11,9 +12,11 @@ using RPG_dotnet.Data;
 namespace RPG_dotnet.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260511184045_AddGameLogicOverhaul")]
+    partial class AddGameLogicOverhaul
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260511184045_AddGameLogicOverhaul.cs
+++ b/Migrations/20260511184045_AddGameLogicOverhaul.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RPG_dotnet.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameLogicOverhaul : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GameActionLogs",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    sessionId = table.Column<int>(type: "int", nullable: false),
+                    actorCharacterId = table.Column<int>(type: "int", nullable: false),
+                    targetCharacterId = table.Column<int>(type: "int", nullable: true),
+                    actionType = table.Column<int>(type: "int", nullable: false),
+                    abilityId = table.Column<int>(type: "int", nullable: true),
+                    damageDealt = table.Column<int>(type: "int", nullable: false),
+                    manaSpent = table.Column<double>(type: "float", nullable: false),
+                    manaGained = table.Column<double>(type: "float", nullable: false),
+                    newPosition = table.Column<float>(type: "real", nullable: true),
+                    turnIndex = table.Column<int>(type: "int", nullable: false),
+                    timestamp = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameActionLogs", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_GameActionLogs_GameSessions_sessionId",
+                        column: x => x.sessionId,
+                        principalTable: "GameSessions",
+                        principalColumn: "gameSessionId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameActionLogs_sessionId",
+                table: "GameActionLogs",
+                column: "sessionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GameActionLogs");
+        }
+    }
+}

--- a/Models/GameActionLog.cs
+++ b/Models/GameActionLog.cs
@@ -1,0 +1,32 @@
+namespace RPG_dotnet.Models;
+
+public class GameActionLog
+{
+    public int id { get; set; }
+
+    public int sessionId { get; set; }
+    public GameSession session { get; set; }
+
+    public int actorCharacterId { get; set; }
+    public int? targetCharacterId { get; set; }
+
+    public GameActionType actionType { get; set; }
+
+    public int? abilityId { get; set; }
+
+    public int damageDealt { get; set; }
+    public double manaSpent { get; set; }
+    public double manaGained { get; set; }
+    public float? newPosition { get; set; }
+
+    public int turnIndex { get; set; }
+    public DateTime timestamp { get; set; } = DateTime.UtcNow;
+}
+
+public enum GameActionType
+{
+    Move,
+    Attack,
+    CastSpell,
+    EndTurn
+}

--- a/Models/GameSession.cs
+++ b/Models/GameSession.cs
@@ -22,6 +22,7 @@ namespace RPG_dotnet.Models
         public int currentTurnPlayerId { get; set; }
 
         public List<SessionCharacterState> participants { get; set; } = new();
+        public List<GameActionLog> actionLog { get; set; } = new();
 
         // Position boundaries (e.g., linear board from 0 to 100)
         public float minPosition { get; set; } = 0f;

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -21,29 +21,17 @@ namespace RPG_dotnet.Services.GameSessionService
 
         public async Task<ServiceResponse<GetGameSessionDto>> CreateGameSessionAsync(int userId, CreateGameSessionDto newSessionDto)
         {
-            var response = new ServiceResponse<GetGameSessionDto>();
-
             if (newSessionDto.characterIds == null || newSessionDto.characterIds.Count != 2)
-            {
-                throw new GenericException("Exactly two character IDs must be provided to create a session.", 422);
-            }
+                throw new GenericException("Exactly two character IDs must be provided.", 422);
 
             var characters = await _context.Characters
                 .Where(c => newSessionDto.characterIds.Contains(c.id))
                 .ToListAsync();
 
             if (characters.Count != 2)
-            {
                 throw new GenericException("One or more character IDs are invalid.", 422);
-            }
 
-            bool hasSupport = characters.Any(c => c.role == RoleType.Support);
-            bool hasVanguard = characters.Any(c => c.role == RoleType.Vanguard);
-
-            if (!hasSupport || !hasVanguard)
-            {
-                throw new GenericException("A valid team must consist of one Support and one Vanguard character.", 422);
-            }
+            ValidateTeamComposition(characters);
 
             var session = new GameSession
             {
@@ -80,87 +68,70 @@ namespace RPG_dotnet.Services.GameSessionService
             _context.GameSessions.Add(session);
             await _context.SaveChangesAsync();
 
-            response.data = _mapper.Map<GetGameSessionDto>(session);
-            response.success = true;
-            return response;
+            return new ServiceResponse<GetGameSessionDto>
+            {
+                success = true,
+                data = _mapper.Map<GetGameSessionDto>(session)
+            };
         }
         public async Task<ServiceResponse<List<GetGameSessionDto>>> GetActiveGameSessionsAsync(int userId)
         {
-            var response = new ServiceResponse<List<GetGameSessionDto>>();
-
-            var sessions = await _context.GameSessions
+            var sessions = await SessionWithFullIncludes()
                 .Where(gs => gs.state == GameSessionState.ACTIVE &&
-                    gs.participants.Any(p => p.userId == userId))
-                .Include(gs => gs.creatorUser)
-                .Include(gs => gs.opponentUser)
-                .Include(gs => gs.participants)
-                    .ThenInclude(p => p.character)
-                .Include(gs => gs.participants)
-                    .ThenInclude(p => p.user)
+                             gs.participants.Any(p => p.userId == userId))
                 .ToListAsync();
 
-            response.data = sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList();
-            response.success = true;
-            return response;
+            return new ServiceResponse<List<GetGameSessionDto>>
+            {
+                success = true,
+                data = sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList()
+            };
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> GetGameSessionByIdAsync(int sessionId)
         {
-            var response = new ServiceResponse<GetGameSessionDto>();
+            var session = await SessionWithFullIncludes()
+                              .FirstOrDefaultAsync(gs => gs.gameSessionId == sessionId)
+                          ?? throw new NotFoundException("Session not found.");
 
-            var session = await _context.GameSessions
-                .Include(gs => gs.creatorUser)
-                .Include(gs => gs.opponentUser)
-                .Include(gs => gs.participants)
-                    .ThenInclude(p => p.character)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == sessionId) ?? throw new NotFoundException("Session not found.");
-            response.data = _mapper.Map<GetGameSessionDto>(session);
-            response.success = true;
-            return response;
+            return new ServiceResponse<GetGameSessionDto>
+            {
+                success = true,
+                data = _mapper.Map<GetGameSessionDto>(session)
+            };
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> MoveCharacterAsync(int userId, MoveActionDto dto)
         {
-            var session = await _context.GameSessions
-                .Include(gs => gs.participants)
-                    .ThenInclude(p => p.character)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE) ?? throw new NotFoundException("Active session not found.");
+            var session = await SessionWithFullIncludes()
+                              .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
+                          ?? throw new NotFoundException("Active session not found.");
+
             Functions.EnsureUserTurn(session, userId);
 
-            var character = session.participants.FirstOrDefault(p => p.characterId == dto.characterId && p.userId == userId) ?? throw new NotFoundException("Character not found in session or not owned by user.");
+            var character = session.participants
+                                .FirstOrDefault(p => p.characterId == dto.characterId && p.userId == userId)
+                            ?? throw new NotFoundException("Character not found in session or not owned by user.");
+
             if (!character.isAlive)
                 throw new GenericException("Character is not alive.", 400);
 
-            if (session.currentTurnPlayerId != userId)
-                throw new GenericException("Player has already acted this turn.", 400);
-
             if (character.role != RoleType.Vanguard)
-                throw new GenericException("Only Vanguard characters are allowed to move.", 403);
+                throw new GenericException("Only Vanguard characters can move.", 403);
 
-            int movement = character.character.movement;
-            int currentPos = (int)character.xPosition;
-            int newPos;
+            if (character.hasActedThisTurn)
+                throw new GenericException("This character has already acted this turn.", 400);
 
-            if (character.team == TeamSide.CREATOR)
-            {
-                newPos = (int)Math.Min(currentPos + movement, session.maxPosition);
-            }
-            else if (character.team == TeamSide.OPPONENT)
-            {
-                newPos = (int)Math.Max(currentPos - movement, session.minPosition);
-            }
-            else
-            {
-                throw new GenericException("Invalid team type for character.", 422);
-            }
+            float newPos = character.team == TeamSide.CREATOR
+                ? Math.Min(character.xPosition + character.character.movement, session.maxPosition)
+                : Math.Max(character.xPosition - character.character.movement, session.minPosition);
 
             character.xPosition = newPos;
             character.hasActedThisTurn = true;
 
-            var nextPlayer = session.participants.FirstOrDefault(p => p.userId != session.currentTurnPlayerId)
-                             ?? throw new GenericException("Could not complete turn", 422);
+            LogAction(session, GameActionType.Move, character.characterId, newPosition: newPos);
 
-            session.currentTurnPlayerId = nextPlayer.userId;
+            TryAdvanceTurn(session, userId);
 
             await _context.SaveChangesAsync();
 
@@ -173,52 +144,62 @@ namespace RPG_dotnet.Services.GameSessionService
 
         public async Task<ServiceResponse<GetGameSessionDto>> AttackCharacterAsync(int userId, AttackCharacterDto dto)
         {
-            var session = await _context.GameSessions
-                .Include(gs => gs.participants)
-                    .ThenInclude(p => p.character)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE) ?? throw new NotFoundException("Active session not found.");
+            var session = await SessionWithFullIncludes()
+                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
+                ?? throw new NotFoundException("Active session not found.");
+
             Functions.EnsureUserTurn(session, userId);
 
-            var attacker = session.participants.FirstOrDefault(p => p.characterId == dto.attackerId && p.userId == userId);
-            var target = session.participants.FirstOrDefault(p => p.characterId == dto.targetId);
+            var attacker = session.participants
+                .FirstOrDefault(p => p.characterId == dto.attackerId && p.userId == userId)
+                ?? throw new NotFoundException("Attacker not found in session or not owned by user.");
 
-            if (attacker == null || target == null)
-                throw new NotFoundException("Invalid attacker or target.");
+            var target = session.participants
+                .FirstOrDefault(p => p.characterId == dto.targetId)
+                ?? throw new NotFoundException("Target not found in session.");
 
             if (!attacker.isAlive || !target.isAlive)
                 throw new GenericException("One or both characters are not alive.", 400);
 
-            if (attacker.character.role == RoleType.Vanguard && !Functions.IsWithinProximity(attacker.xPosition, target.xPosition))
-                throw new GenericException("Vanguard characters can only attack targets in close proximity.", 400);
+            // FIX #8: Support cannot basic attack. Their damage comes from CastSpell.
+            if (attacker.role != RoleType.Vanguard)
+                throw new GenericException("Only Vanguard characters can perform a basic attack.", 403);
 
+            if (!Functions.IsWithinProximity(attacker.xPosition, target.xPosition))
+                throw new GenericException("Vanguard can only attack targets in close proximity.", 400);
 
             if (attacker.hasActedThisTurn)
-                throw new GenericException("Attacker has already acted this turn.", 400);
+                throw new GenericException("This character has already acted this turn.", 400);
 
-            target.currentHealth -= attacker.character.baseDamage;
-            if (target.currentHealth <= 0)
-            {
-                target.isAlive = false;
-                target.currentHealth = 0;
-            }
+            if (target.userId == userId)
+                throw new GenericException("Cannot attack your own character.", 400);
 
-            if (attacker.currentMana < attacker.character.mana)
+            int damage = attacker.character.baseDamage;
+            target.currentHealth = Math.Max(0, target.currentHealth - damage);
+            if (target.currentHealth <= 0) target.isAlive = false;
+
+            double manaGained = 0;
+            if (attacker.currentMana < attacker.maxMana)
             {
+                double before = attacker.currentMana;
                 attacker.currentMana = Math.Min(
                     attacker.currentMana + attacker.character.manaGainPerAttack,
-                    attacker.character.mana
-                );
+                    attacker.maxMana);
+                manaGained = attacker.currentMana - before;
             }
 
             attacker.hasActedThisTurn = true;
 
-            var nextPlayer = session.participants.FirstOrDefault(p => p.userId != session.currentTurnPlayerId)
-                             ?? throw new GenericException("Could not complete turn", 422);
-
-            session.currentTurnPlayerId = nextPlayer.userId;
+            LogAction(session, GameActionType.Attack,
+                actorCharacterId: attacker.characterId,
+                targetCharacterId: target.characterId,
+                damageDealt: damage,
+                manaGained: manaGained);
 
             Functions.CheckVictoryCondition(session);
-            Functions.AdvanceTurn(session);
+
+            if (session.state == GameSessionState.ACTIVE)
+                TryAdvanceTurn(session, userId);
 
             await _context.SaveChangesAsync();
 
@@ -231,57 +212,44 @@ namespace RPG_dotnet.Services.GameSessionService
 
         public async Task<ServiceResponse<GetGameSessionDto>> AbandonSessionAsync(int userId, int sessionId)
         {
-            var response = new ServiceResponse<GetGameSessionDto>();
+            var session = await SessionWithFullIncludes()
+                              .FirstOrDefaultAsync(gs => gs.gameSessionId == sessionId &&
+                                                         gs.state != GameSessionState.ABANDONED)
+                          ?? throw new NotFoundException("Session not found.");
 
-            var session = await _context.GameSessions
-                .Include(gs => gs.participants)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == sessionId && gs.state != GameSessionState.ABANDONED) ?? throw new NotFoundException("Session not found.");
+            if (session.creatorUserId != userId && session.opponentUserId != userId)
+                throw new GenericException("You are not a participant in this session.", 403);
+
             session.state = GameSessionState.ABANDONED;
-
             await _context.SaveChangesAsync();
 
-            response.data = _mapper.Map<GetGameSessionDto>(session);
-            response.success = true;
-            return response;
+            return new ServiceResponse<GetGameSessionDto>
+            {
+                success = true,
+                data = _mapper.Map<GetGameSessionDto>(session)
+            };
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> AcceptSessionAsync(int userId, AcceptGameSessionDto dto)
         {
-            var response = new ServiceResponse<GetGameSessionDto>();
+            var session = await SessionWithFullIncludes()
+                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.opponentUserId == userId)
+                ?? throw new NotFoundException("Session not found.");
 
-            var session = await _context.GameSessions
-                .Include(gs => gs.participants)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.opponentUserId == userId) ?? throw new NotFoundException("Session not found.");
             if (session.state != GameSessionState.PENDING)
-            {
-                throw new NotFoundException("Session is not in a pending state.");
-            }
+                throw new GenericException("Only pending sessions can be accepted.", 422);
 
             if (dto.characterIds == null || dto.characterIds.Count != 2)
-            {
-                throw new GenericException("Exactly two character IDs must be provided to create a session.", 422);
-            }
+                throw new GenericException("Exactly two character IDs must be provided.", 422);
 
             var characters = await _context.Characters
                 .Where(c => dto.characterIds.Contains(c.id))
                 .ToListAsync();
 
             if (characters.Count != 2)
-            {
                 throw new GenericException("One or more character IDs are invalid.", 422);
-            }
 
-            bool hasSupport = characters.Any(c => c.role == RoleType.Support);
-            bool hasVanguard = characters.Any(c => c.role == RoleType.Vanguard);
-
-            if (!hasSupport || !hasVanguard)
-            {
-                throw new GenericException("A valid team must consist of one Support and one Vanguard character.", 422);
-            }
-
-            var random = new Random();
-            var startingPlayer = session.participants[random.Next(session.participants.Count)];
-            session.currentTurnPlayerId = startingPlayer.userId;
+            ValidateTeamComposition(characters);
 
             foreach (var character in characters)
             {
@@ -290,7 +258,9 @@ namespace RPG_dotnet.Services.GameSessionService
                     session = session,
                     characterId = character.id,
                     userId = userId,
-                    xPosition = session.minPosition,
+                    // FIX #4: opponent starts at maxPosition not minPosition —
+                    // both teams were spawning at 0, facing the same direction.
+                    xPosition = session.maxPosition,
                     currentHealth = character.hitpoints,
                     maxHealth = character.hitpoints,
                     currentMana = 0.1 * character.mana,
@@ -302,113 +272,110 @@ namespace RPG_dotnet.Services.GameSessionService
                 });
             }
 
+            var random = new Random();
+            session.currentTurnPlayerId = random.Next(2) == 0
+                ? session.creatorUserId
+                : session.opponentUserId;
+            session.currentTurnIndex = 0;
             session.state = GameSessionState.ACTIVE;
+
             await _context.SaveChangesAsync();
 
-            response.data = _mapper.Map<GetGameSessionDto>(session);
-            response.success = true;
-            return response;
+            return new ServiceResponse<GetGameSessionDto>
+            {
+                success = true,
+                data = _mapper.Map<GetGameSessionDto>(session)
+            };
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> RejectSessionAsync(int userId, int sessionId)
         {
-            var response = new ServiceResponse<GetGameSessionDto>();
+            var session = await SessionWithFullIncludes()
+                              .FirstOrDefaultAsync(gs => gs.gameSessionId == sessionId && gs.opponentUserId == userId)
+                          ?? throw new NotFoundException("Session not found.");
 
-            var session = await _context.GameSessions
-                .Include(gs => gs.participants)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == sessionId) ?? throw new NotFoundException("Session not found.");
             if (session.state != GameSessionState.PENDING)
-            {
                 throw new GenericException("Only pending sessions can be rejected.", 422);
-            }
 
             session.state = GameSessionState.REJECTED;
             await _context.SaveChangesAsync();
 
-            response.data = _mapper.Map<GetGameSessionDto>(session);
-            response.success = true;
-            return response;
+            return new ServiceResponse<GetGameSessionDto>
+            {
+                success = true,
+                data = _mapper.Map<GetGameSessionDto>(session)
+            };
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> CastSpellAsync(int userId, CastSpellDto dto)
         {
-            var response = new ServiceResponse<GetGameSessionDto>();
+            var session = await SessionWithFullIncludes()
+                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
+                ?? throw new NotFoundException("Game session not found.");
 
-            var session = await _context.GameSessions
-                .Include(gs => gs.participants)
-                    .ThenInclude(p => p.character)
-                        .ThenInclude(c => c.abilities)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId) ?? throw new NotFoundException("Game session not found.");
-            Functions.EnsureUserTurn(session, dto.userId);
+            // FIX #5: only the JWT-sourced userId is used here
+            Functions.EnsureUserTurn(session, userId);
 
             var caster = session.participants
-                .FirstOrDefault(p => p.characterId == dto.casterId && p.userId == dto.userId);
+                .FirstOrDefault(p => p.characterId == dto.casterId && p.userId == userId)
+                ?? throw new GenericException("Caster not found or not owned by this user.", 422);
+
             var target = session.participants
-                .FirstOrDefault(p => p.characterId == dto.targetId);
+                .FirstOrDefault(p => p.characterId == dto.targetId)
+                ?? throw new GenericException("Target not found.", 422);
 
-            if (caster == null || !caster.isAlive)
-            {
-                throw new GenericException("Caster not found or is not alive.", 422);
-            }
+            if (!caster.isAlive)
+                throw new GenericException("Caster is not alive.", 422);
 
-            if (target == null || !target.isAlive)
-            {
-                throw new GenericException("Target not found or is not alive.", 422);
-            }
+            if (!target.isAlive)
+                throw new GenericException("Target is not alive.", 422);
 
-            if (caster.character.role == RoleType.Vanguard && !Functions.IsWithinProximity(caster.xPosition, target.xPosition))
+            if (caster.hasActedThisTurn)
+                throw new GenericException("This character has already acted this turn.", 400);
+
+            // FIX #8: Vanguard needs proximity to cast; Support can cast from anywhere
+            if (caster.role == RoleType.Vanguard &&
+                !Functions.IsWithinProximity(caster.xPosition, target.xPosition))
                 throw new GenericException("Vanguard characters can only cast spells on nearby targets.", 422);
 
-
-            if (session.currentTurnPlayerId != userId)
-            {
-                throw new GenericException("Caster has already acted this turn.", 422);
-            }
-
             var ability = caster.character.abilities
-                .FirstOrDefault(a => a.id == dto.abilityId) ?? throw new GenericException("Ability not found.", 422);
+                .FirstOrDefault(a => a.id == dto.abilityId)
+                ?? throw new GenericException("Ability not found on this character.", 422);
+
             if (caster.currentMana < ability.manaCost)
-            {
-                throw new GenericException("Not enough mana to cast the spell.", 422);
-            }
+                throw new GenericException("Not enough mana to cast this spell.", 422);
 
-            // Deduct mana and apply damage
             caster.currentMana -= ability.manaCost;
-            target.currentHealth -= ability.damage;
-
-            if (target.currentHealth <= 0)
-            {
-                target.currentHealth = 0;
-                target.isAlive = false;
-            }
+            int damage = ability.damage;
+            target.currentHealth = Math.Max(0, target.currentHealth - damage);
+            if (target.currentHealth <= 0) target.isAlive = false;
 
             caster.hasActedThisTurn = true;
 
-            // Change turn and check win conditions
-            var nextPlayer = session.participants
-                .FirstOrDefault(p => p.userId != session.currentTurnPlayerId)
-                ?? throw new GenericException("Could not complete turn", 422);
+            LogAction(session, GameActionType.CastSpell,
+                actorCharacterId: caster.characterId,
+                targetCharacterId: target.characterId,
+                abilityId: ability.id,
+                damageDealt: damage,
+                manaSpent: ability.manaCost);
 
-            session.currentTurnPlayerId = nextPlayer.userId;
-
+            // FIX #6 #9
             Functions.CheckVictoryCondition(session);
-            Functions.AdvanceTurn(session);
+
+            if (session.state == GameSessionState.ACTIVE)
+                TryAdvanceTurn(session, userId);
 
             await _context.SaveChangesAsync();
 
-            response.success = true;
-            response.data = _mapper.Map<GetGameSessionDto>(session);
-            return response;
+            return new ServiceResponse<GetGameSessionDto>
+            {
+                success = true,
+                data = _mapper.Map<GetGameSessionDto>(session)
+            };
         }
         public async Task<ServiceResponse<List<GetGameSessionDto>>> GetGameSessionsByUserIdAsync(int userId, GameSessionState? state = null)
         {
-
-            var response = new ServiceResponse<List<GetGameSessionDto>>();
-            var query = _context.GameSessions
-                .Include(gs => gs.creatorUser)
-                .Include(gs => gs.opponentUser)
-                .Include(gs => gs.participants)
-                    .ThenInclude(p => p.character)
+            var query = SessionWithFullIncludes()
                 .Where(gs => gs.creatorUserId == userId || gs.opponentUserId == userId);
 
             if (state.HasValue)
@@ -417,95 +384,97 @@ namespace RPG_dotnet.Services.GameSessionService
             var sessions = await query.ToListAsync();
 
             if (!sessions.Any())
-                throw new NotFoundException("No game sessions found for the specified user");
+                throw new NotFoundException("No game sessions found for the specified user.");
 
-            response.data = sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList();
-            response.success = true;
-            return response;
+            return new ServiceResponse<List<GetGameSessionDto>>
+            {
+                success = true,
+                data = sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList()
+            };
         }
 
-        public async Task<ServiceResponse<GetGameSessionDto>> JoinGameSessionAsync(JoinGameSessionDto dto)
+        public async Task<ServiceResponse<GetGameSessionDto>> EndTurnAsync(
+            int userId, EndTurnDto dto)
         {
-            var response = new ServiceResponse<GetGameSessionDto>();
-            var session = await _context.GameSessions
-                .Include(gs => gs.participants)
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId) ?? throw new NotFoundException("Game session not found");
-            if (session.opponentUserId != dto.opponentUserId)
-                throw new GenericException("You are not authorized to join this session", 403);
+            var session = await SessionWithFullIncludes()
+                              .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
+                          ?? throw new NotFoundException("Active session not found.");
 
-            if (session.state != GameSessionState.PENDING)
-                throw new GenericException("This session is not joinable", 400);
+            Functions.EnsureUserTurn(session, userId);
 
-            if (session.participants.Any(p => p.userId == dto.opponentUserId))
-                throw new GenericException("You have already joined this session", 400);
+            foreach (var p in session.participants.Where(p => p.userId == userId && p.isAlive))
+                p.hasActedThisTurn = true;
 
-            var characters = await _context.Characters
-                .Where(c => dto.characterIds.Contains(c.id))
-                .ToListAsync();
+            LogAction(session, GameActionType.EndTurn,
+                actorCharacterId: session.participants.First(p => p.userId == userId).characterId);
 
-            if (characters.Count != dto.characterIds.Count)
-                throw new GenericException("One or more characters are invalid or do not belong to the user", 400);
-
-            foreach (var character in characters)
-            {
-                session.participants.Add(new SessionCharacterState
-                {
-                    sessionId = session.gameSessionId,
-                    characterId = character.id,
-                    userId = dto.opponentUserId,
-                    character = character,
-                    currentHealth = character.hitpoints,
-                    currentMana = 0.1 * character.mana,
-                    maxHealth = character.hitpoints,
-                    maxMana = character.mana,
-                    isAlive = true,
-                    role = character.role,
-                    hasActedThisTurn = false,
-                    xPosition = session.maxPosition,
-                    team = TeamSide.OPPONENT
-                });
-            }
-
-            session.state = GameSessionState.ACTIVE;
-            var random = new Random();
-            session.currentTurnPlayerId = random.Next(0, 2) == 0
-                ? session.creatorUserId
-                : session.opponentUserId;
-
-            session.currentTurnIndex = 0;
+            Functions.AdvanceTurn(session);
 
             await _context.SaveChangesAsync();
 
-            response.data = new GetGameSessionDto
+            return new ServiceResponse<GetGameSessionDto>
             {
-                gameSessionId = session.gameSessionId,
-                startedAt = session.startedAt,
-                state = session.state,
-                currentTurnIndex = session.currentTurnIndex,
-                currentTurnPlayerId = session.currentTurnPlayerId,
-                winnerUserId = session.winnerUserId,
-                minPosition = session.minPosition,
-                maxPosition = session.maxPosition,
-                participants = session.participants.Select(p => new GetSessionCharacterStateDto
-                {
-                    sessionCharacterId = p.sessionCharacterId,
-                    sessionId = p.sessionId,
-                    characterId = p.characterId,
-                    characterName = p.character?.name ?? "Unknown",
-                    userId = p.userId,
-                    currentHealth = p.currentHealth,
-                    currentMana = p.currentMana,
-                    maxHealth = p.maxHealth,
-                    maxMana = p.maxMana,
-                    isAlive = p.isAlive,
-                    role = p.role,
-                    hasActedThisTurn = p.hasActedThisTurn,
-                    xPosition = p.xPosition,
-                    team = p.team
-                }).ToList()
+                success = true,
+                data = _mapper.Map<GetGameSessionDto>(session)
             };
+        }
 
-            return response;
+        private IQueryable<GameSession> SessionWithFullIncludes() =>
+            _context.GameSessions
+                .Include(gs => gs.creatorUser)
+                .Include(gs => gs.opponentUser)
+                .Include(gs => gs.participants)
+                .ThenInclude(p => p.character)
+                .ThenInclude(c => c.abilities)
+                .Include(gs => gs.participants)
+                .ThenInclude(p => p.user)
+                .Include(gs => gs.actionLog);
+
+        private static void LogAction(
+            GameSession session,
+            GameActionType actionType,
+            int actorCharacterId,
+            int? targetCharacterId = null,
+            int? abilityId = null,
+            int damageDealt = 0,
+            double manaSpent = 0,
+            double manaGained = 0,
+            float? newPosition = null)
+        {
+            session.actionLog.Add(new GameActionLog
+            {
+                sessionId = session.gameSessionId,
+                actorCharacterId = actorCharacterId,
+                targetCharacterId = targetCharacterId,
+                actionType = actionType,
+                abilityId = abilityId,
+                damageDealt = damageDealt,
+                manaSpent = manaSpent,
+                manaGained = manaGained,
+                newPosition = newPosition,
+                turnIndex = session.currentTurnIndex,
+                timestamp = DateTime.UtcNow
+            });
+        }
+
+        private static void TryAdvanceTurn(GameSession session, int userId)
+        {
+            bool allActed = session.participants
+                .Where(p => p.userId == userId && p.isAlive)
+                .All(p => p.hasActedThisTurn);
+
+            if (allActed)
+                Functions.AdvanceTurn(session);
+        }
+
+        private static void ValidateTeamComposition(List<Characters> characters)
+        {
+            bool hasSupport = characters.Any(c => c.role == RoleType.Support);
+            bool hasVanguard = characters.Any(c => c.role == RoleType.Vanguard);
+
+            if (!hasSupport || !hasVanguard)
+                throw new GenericException(
+                    "A valid team must consist of one Support and one Vanguard character.", 422);
         }
 
     }

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -70,6 +70,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<GetGameSessionDto>
             {
+                message = "Created new session successfully",
                 success = true,
                 data = _mapper.Map<GetGameSessionDto>(session)
             };
@@ -83,6 +84,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<List<GetGameSessionDto>>
             {
+                message = "Retrieved active sessions successfully",
                 success = true,
                 data = sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList()
             };
@@ -96,6 +98,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<GetGameSessionDto>
             {
+                message = "Retrieved session successfully",
                 success = true,
                 data = _mapper.Map<GetGameSessionDto>(session)
             };
@@ -216,6 +219,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<GetGameSessionDto>
             {
+                message = "Session abandoned successfully",
                 success = true,
                 data = _mapper.Map<GetGameSessionDto>(session)
             };
@@ -272,6 +276,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<GetGameSessionDto>
             {
+                message = "Session accepted successfully",
                 success = true,
                 data = _mapper.Map<GetGameSessionDto>(session)
             };
@@ -291,6 +296,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<GetGameSessionDto>
             {
+                message = "Session rejected successfully",
                 success = true,
                 data = _mapper.Map<GetGameSessionDto>(session)
             };
@@ -355,6 +361,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<GetGameSessionDto>
             {
+                message = "Spell cast successfully",
                 success = true,
                 data = _mapper.Map<GetGameSessionDto>(session)
             };
@@ -374,6 +381,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<List<GetGameSessionDto>>
             {
+                message = "Retrieved game sessions successfully",
                 success = true,
                 data = sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList()
             };
@@ -400,6 +408,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             return new ServiceResponse<GetGameSessionDto>
             {
+                message = "Turn ended successfully",
                 success = true,
                 data = _mapper.Map<GetGameSessionDto>(session)
             };

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -161,7 +161,6 @@ namespace RPG_dotnet.Services.GameSessionService
             if (!attacker.isAlive || !target.isAlive)
                 throw new GenericException("One or both characters are not alive.", 400);
 
-            // FIX #8: Support cannot basic attack. Their damage comes from CastSpell.
             if (attacker.role != RoleType.Vanguard)
                 throw new GenericException("Only Vanguard characters can perform a basic attack.", 403);
 
@@ -258,8 +257,6 @@ namespace RPG_dotnet.Services.GameSessionService
                     session = session,
                     characterId = character.id,
                     userId = userId,
-                    // FIX #4: opponent starts at maxPosition not minPosition —
-                    // both teams were spawning at 0, facing the same direction.
                     xPosition = session.maxPosition,
                     currentHealth = character.hitpoints,
                     maxHealth = character.hitpoints,
@@ -313,7 +310,6 @@ namespace RPG_dotnet.Services.GameSessionService
                 .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
                 ?? throw new NotFoundException("Game session not found.");
 
-            // FIX #5: only the JWT-sourced userId is used here
             Functions.EnsureUserTurn(session, userId);
 
             var caster = session.participants
@@ -333,7 +329,6 @@ namespace RPG_dotnet.Services.GameSessionService
             if (caster.hasActedThisTurn)
                 throw new GenericException("This character has already acted this turn.", 400);
 
-            // FIX #8: Vanguard needs proximity to cast; Support can cast from anywhere
             if (caster.role == RoleType.Vanguard &&
                 !Functions.IsWithinProximity(caster.xPosition, target.xPosition))
                 throw new GenericException("Vanguard characters can only cast spells on nearby targets.", 422);
@@ -359,7 +354,6 @@ namespace RPG_dotnet.Services.GameSessionService
                 damageDealt: damage,
                 manaSpent: ability.manaCost);
 
-            // FIX #6 #9
             Functions.CheckVictoryCondition(session);
 
             if (session.state == GameSessionState.ACTIVE)

--- a/Services/GameSessionService/IGameSessionService.cs
+++ b/Services/GameSessionService/IGameSessionService.cs
@@ -15,8 +15,6 @@ namespace RPG_dotnet.Services.GameSessionService
         Task<ServiceResponse<GetGameSessionDto>> RejectSessionAsync(int userId, int sessionId);
         Task<ServiceResponse<GetGameSessionDto>> CastSpellAsync(int userId,CastSpellDto dto);
         Task<ServiceResponse<List<GetGameSessionDto>>> GetGameSessionsByUserIdAsync(int userId, GameSessionState? state = null);
-        Task<ServiceResponse<GetGameSessionDto>> JoinGameSessionAsync(JoinGameSessionDto dto);
-
-        
+        Task<ServiceResponse<GetGameSessionDto>> EndTurnAsync(int userId, EndTurnDto dto);
     }
 }


### PR DESCRIPTION
### Short Description
Complete game logic overhaul — fixes broken turn system, security issues, and adds action logging for frontend readiness.

### Details
**What did you change?**
- Rewrote the turn system in `Functions.cs` (`AdvanceTurn`) to operate at player level instead of raw character index
- Fixed `EnsureUserTurn` in `Functions.cs` to compare `p.userId` directly instead of accessing the unloaded `p.user` navigation property
- Fixed `CheckVictoryCondition` in `Functions.cs` to assign `winnerUserId` on session completion
- Fixed opponent spawn position in `GameSessionService.AcceptSessionAsync` — opponent characters now start at `maxPosition` instead of `minPosition`
- Fixed `CastSpellAsync` to use only the JWT-sourced `userId` — removed the user-controlled `userId` field from `CastSpellDto`
- Fixed turn advancement in `MoveCharacterAsync`, `AttackCharacterAsync`, and `CastSpellAsync` — turn now switches only after all of the current player's alive characters have acted
- Added role enforcement — Support characters can no longer perform basic attacks; Vanguard must be in proximity to cast spells
- Added `GameActionLog` model and `GameActionLogs` table to persist a record of every action taken per turn
- Added `EndTurnAsync` and `PUT /endturn` endpoint so a player can explicitly pass without acting
- Added centralised `SessionWithFullIncludes()` helper to ensure navigation properties are always eagerly loaded
- Removed `JoinGameSession` — `AcceptSession` is now the single entry point for the opponent with proper validation
- Added `DesignTimeDbContextFactory` to support offline migration generation

**Why did you make the change?**
- The turn system was using character index to track player turns causing it to cycle through all 4 characters individually and never reset `hasActedThisTurn` correctly when a character died
- `EnsureUserTurn` threw a `NullReferenceException` on every game action because the `user` navigation property was never included in the EF query
- `winnerUserId` was never set on completion so the frontend had no way to determine who won
- Both teams spawned at position 0 making positional combat impossible
- `CastSpellDto.userId` was user-supplied in the request body, allowing a client to bypass turn enforcement by impersonating another player
- Without an explicit end-turn endpoint, a player with no valid actions could stall the session indefinitely
- Without action logs, the frontend has no way to animate or replay what happened each turn

**Type of change:**
- [x] New feature or functionality added
- [x] Fixing a bug or issue in existing functionality