### PR TITLE
Feature/heroic spirits roster

### DIFF
--- a/Dtos/Characters/AddAbilityDto.cs
+++ b/Dtos/Characters/AddAbilityDto.cs
@@ -11,5 +11,8 @@ namespace RPG_dotnet.Dtos.Characters
         public string description { get; set; } = string.Empty;
         public int manaCost { get; set; }
         public int damage { get; set; }
+        public AbilityEffect effect { get; set; } = AbilityEffect.None;
+        public int effectValue { get; set; } = 0;
+        public AbilityTargetType targetType { get; set; } = AbilityTargetType.Enemy;
     }
 }

--- a/Dtos/Characters/AddCharacterDto.cs
+++ b/Dtos/Characters/AddCharacterDto.cs
@@ -18,7 +18,8 @@ namespace RPG_dotnet.Dtos.Characters
         public int manaGainPerAttack { get; set; }
         public RpgClass fighterClass { get; set; }
         public RoleType role { get; set; }
-
         public List<AddAbilityDto> abilities { get; set; } // instead of abilityIds
+        public string description { get; set; } = string.Empty;
+        public bool isPlayable { get; set; } = false;
     }
 }

--- a/Dtos/Characters/GetAbilityDto.cs
+++ b/Dtos/Characters/GetAbilityDto.cs
@@ -11,8 +11,10 @@ namespace RPG_dotnet.Dtos.Characters
         public string name { get; set; }
         public string effect { get; set; }
         public int manaCost { get; set; }
-
         public int damage { get; set; }
+        public string description { get; set; } = string.Empty;
+        public int effectValue { get; set; }
+        public AbilityTargetType targetType { get; set; }
     }
 
 }

--- a/Dtos/Characters/GetCharacterDto.cs
+++ b/Dtos/Characters/GetCharacterDto.cs
@@ -19,8 +19,8 @@ namespace RPG_dotnet.Dtos.Characters
         public int manaGainPerAttack { get; set; }
         public RoleType role { get; set; }
         public RpgClass fighterClass { get; set; }
-
         public List<GetAbilityDto> abilities { get; set; } = new();
+        public string description { get; set; } = string.Empty;
+        public bool isPlayable { get; set; }
     }
-
 }

--- a/Dtos/GameSession/GetSessionCharacterDto.cs
+++ b/Dtos/GameSession/GetSessionCharacterDto.cs
@@ -21,5 +21,9 @@ namespace RPG_dotnet.Dtos.GameSession
         public bool hasActedThisTurn { get; set; }
         public float xPosition { get; set; }
         public TeamSide team { get; set; }
+        public bool isStunned { get; set; }
+        public int poisonStacks { get; set; }
+        public int poisonDamagePerTick { get; set; }
+        public int reviveCount { get; set; }
     }
 }

--- a/Migrations/20260514210508_AddHeroicSpiritsRoster.Designer.cs
+++ b/Migrations/20260514210508_AddHeroicSpiritsRoster.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using RPG_dotnet.Data;
 
@@ -11,9 +12,11 @@ using RPG_dotnet.Data;
 namespace RPG_dotnet.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260514210508_AddHeroicSpiritsRoster")]
+    partial class AddHeroicSpiritsRoster
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260514210508_AddHeroicSpiritsRoster.cs
+++ b/Migrations/20260514210508_AddHeroicSpiritsRoster.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RPG_dotnet.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHeroicSpiritsRoster : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "isStunned",
+                table: "SessionCharacterStates",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "poisonDamagePerTick",
+                table: "SessionCharacterStates",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "poisonStacks",
+                table: "SessionCharacterStates",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "reviveCount",
+                table: "SessionCharacterStates",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "description",
+                table: "Characters",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "isPlayable",
+                table: "Characters",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "effect",
+                table: "Abilities",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "effectValue",
+                table: "Abilities",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "targetType",
+                table: "Abilities",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "isStunned",
+                table: "SessionCharacterStates");
+
+            migrationBuilder.DropColumn(
+                name: "poisonDamagePerTick",
+                table: "SessionCharacterStates");
+
+            migrationBuilder.DropColumn(
+                name: "poisonStacks",
+                table: "SessionCharacterStates");
+
+            migrationBuilder.DropColumn(
+                name: "reviveCount",
+                table: "SessionCharacterStates");
+
+            migrationBuilder.DropColumn(
+                name: "description",
+                table: "Characters");
+
+            migrationBuilder.DropColumn(
+                name: "isPlayable",
+                table: "Characters");
+
+            migrationBuilder.DropColumn(
+                name: "effect",
+                table: "Abilities");
+
+            migrationBuilder.DropColumn(
+                name: "effectValue",
+                table: "Abilities");
+
+            migrationBuilder.DropColumn(
+                name: "targetType",
+                table: "Abilities");
+        }
+    }
+}

--- a/Models/Ability.cs
+++ b/Models/Ability.cs
@@ -11,5 +11,11 @@ namespace RPG_dotnet.Models
         public int damage { get; set; } = 0;
         public int characterId { get; set; }
         public Characters character { get; set; }
+        public AbilityEffect effect { get; set; } = AbilityEffect.None;
+        public int effectValue { get; set; } = 0;
+
+        // Who this ability can legally target
+        public AbilityTargetType targetType { get; set; } = AbilityTargetType.Enemy;
+
     }
 }

--- a/Models/Characters.cs
+++ b/Models/Characters.cs
@@ -17,6 +17,8 @@ namespace RPG_dotnet.Models
         public int movement { get; set; } = 2;
         public int baseDamage { get; set; } = 10;
         public int manaGainPerAttack { get; set; } = 10;
+        public string description { get; set; } = "A young warrior with a long history of victory.";
+        public bool isPlayable { get; set; }
         public RpgClass fighterClass { get; set; } = RpgClass.Archer;
         public RoleType role { get; set; } = RoleType.Vanguard;
         public List<Ability> abilities { get; set; } = new();

--- a/Models/RpgClass.cs
+++ b/Models/RpgClass.cs
@@ -39,4 +39,27 @@ namespace RPG_dotnet.Models
         CREATOR,
         OPPONENT
     }
+
+    // New: drives the special effect a Noble Phantasm applies on cast
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum AbilityEffect
+    {
+        None,
+        Heal,
+        ManaDrain,
+        Stun,
+        Poison,
+        MultiTarget,
+        DefensePierce,
+        PositionPush,
+        Revive
+    }
+
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum AbilityTargetType
+    {
+        Enemy,
+        Ally,
+        AllEnemies
+    }
 }

--- a/Models/SessionCharacterState.cs
+++ b/Models/SessionCharacterState.cs
@@ -31,5 +31,9 @@ namespace RPG_dotnet.Models
         public RoleType role { get; set; }
         public bool hasActedThisTurn { get; set; } = false;
         public TeamSide team { get; set; }
+        public bool isStunned { get; set; } = false;
+        public int poisonStacks { get; set; } = 0;
+        public int poisonDamagePerTick { get; set; } = 0;
+        public int reviveCount { get; set; } = 0;
     }
 }

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -19,19 +19,13 @@ namespace RPG_dotnet.Services.GameSessionService
             _mapper = mapper;
         }
 
-        public async Task<ServiceResponse<GetGameSessionDto>> CreateGameSessionAsync(int userId, CreateGameSessionDto newSessionDto)
+        public async Task<ServiceResponse<GetGameSessionDto>> CreateGameSessionAsync(
+            int userId, CreateGameSessionDto newSessionDto)
         {
             if (newSessionDto.characterIds == null || newSessionDto.characterIds.Count != 2)
                 throw new GenericException("Exactly two character IDs must be provided.", 422);
 
-            var characters = await _context.Characters
-                .Where(c => newSessionDto.characterIds.Contains(c.id) && c.isPlayable)
-                .ToListAsync();
-
-            if (characters.Count != 2)
-                throw new GenericException("One or more character IDs are invalid.", 422);
-
-            ValidateTeamComposition(characters);
+            var characters = await LoadAndValidateCharactersAsync(newSessionDto.characterIds);
 
             var session = new GameSession
             {
@@ -61,15 +55,21 @@ namespace RPG_dotnet.Services.GameSessionService
                     isAlive = true,
                     role = character.role,
                     hasActedThisTurn = false,
-                    team = TeamSide.CREATOR
+                    team = TeamSide.CREATOR,
+                    reviveCount = character.fighterClass == RpgClass.Berserker ? 1 : 0
                 });
             }
 
             _context.GameSessions.Add(session);
             await _context.SaveChangesAsync();
 
-            return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Created new session successfully");
+            var created = await SessionWithFullIncludes()
+                .FirstAsync(gs => gs.gameSessionId == session.gameSessionId);
+
+            return ServiceResponse<GetGameSessionDto>.Success(
+                _mapper.Map<GetGameSessionDto>(created), "Created new session successfully");
         }
+
         public async Task<ServiceResponse<List<GetGameSessionDto>>> GetActiveGameSessionsAsync(int userId)
         {
             var sessions = await SessionWithFullIncludes()
@@ -77,7 +77,9 @@ namespace RPG_dotnet.Services.GameSessionService
                              gs.participants.Any(p => p.userId == userId))
                 .ToListAsync();
 
-            return ServiceResponse<List<GetGameSessionDto>>.Success(sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList(), "Retrieved active sessions successfully");
+            return ServiceResponse<List<GetGameSessionDto>>.Success(
+                sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList(),
+                "Retrieved active sessions successfully");
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> GetGameSessionByIdAsync(int sessionId)
@@ -86,7 +88,8 @@ namespace RPG_dotnet.Services.GameSessionService
                               .FirstOrDefaultAsync(gs => gs.gameSessionId == sessionId)
                           ?? throw new NotFoundException("Session not found.");
 
-            return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Retrieved session successfully");
+            return ServiceResponse<GetGameSessionDto>.Success(
+                _mapper.Map<GetGameSessionDto>(session), "Retrieved session successfully");
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> MoveCharacterAsync(int userId, MoveActionDto dto)
@@ -110,6 +113,9 @@ namespace RPG_dotnet.Services.GameSessionService
             if (character.hasActedThisTurn)
                 throw new GenericException("This character has already acted this turn.", 400);
 
+            if (character.isStunned)
+                throw new GenericException("This character is stunned and cannot act.", 400);
+
             float newPos = character.team == TeamSide.CREATOR
                 ? Math.Min(character.xPosition + character.character.movement, session.maxPosition)
                 : Math.Max(character.xPosition - character.character.movement, session.minPosition);
@@ -118,18 +124,20 @@ namespace RPG_dotnet.Services.GameSessionService
             character.hasActedThisTurn = true;
 
             LogAction(session, GameActionType.Move, character.characterId, newPosition: newPos);
-
             TryAdvanceTurn(session, userId);
 
             await _context.SaveChangesAsync();
 
-            return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Character moved successfully");
+            return ServiceResponse<GetGameSessionDto>.Success(
+                _mapper.Map<GetGameSessionDto>(session), "Character moved successfully");
         }
 
-        public async Task<ServiceResponse<GetGameSessionDto>> AttackCharacterAsync(int userId, AttackCharacterDto dto)
+        public async Task<ServiceResponse<GetGameSessionDto>> AttackCharacterAsync(
+            int userId, AttackCharacterDto dto)
         {
             var session = await SessionWithFullIncludes()
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
+                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId
+                                        && gs.state == GameSessionState.ACTIVE)
                 ?? throw new NotFoundException("Active session not found.");
 
             Functions.EnsureUserTurn(session, userId);
@@ -145,11 +153,8 @@ namespace RPG_dotnet.Services.GameSessionService
             if (!attacker.isAlive || !target.isAlive)
                 throw new GenericException("One or both characters are not alive.", 400);
 
-            if (attacker.role != RoleType.Vanguard)
-                throw new GenericException("Only Vanguard characters can perform a basic attack.", 403);
-
-            if (!Functions.IsWithinProximity(attacker.xPosition, target.xPosition))
-                throw new GenericException("Vanguard can only attack targets in close proximity.", 400);
+            if (attacker.isStunned)
+                throw new GenericException("This character is stunned and cannot act.", 400);
 
             if (attacker.hasActedThisTurn)
                 throw new GenericException("This character has already acted this turn.", 400);
@@ -157,9 +162,11 @@ namespace RPG_dotnet.Services.GameSessionService
             if (target.userId == userId)
                 throw new GenericException("Cannot attack your own character.", 400);
 
-            int damage = attacker.character.baseDamage;
-            target.currentHealth = Math.Max(0, target.currentHealth - damage);
-            if (target.currentHealth <= 0) target.isAlive = false;
+            if (attacker.role == RoleType.Vanguard &&
+                !Functions.IsWithinProximity(attacker.xPosition, target.xPosition))
+                throw new GenericException("Vanguard characters can only attack targets in close proximity.", 400);
+
+            int damageDealt = ApplyDamage(target, attacker.character.baseDamage);
 
             double manaGained = 0;
             if (attacker.currentMana < attacker.maxMana)
@@ -176,7 +183,7 @@ namespace RPG_dotnet.Services.GameSessionService
             LogAction(session, GameActionType.Attack,
                 actorCharacterId: attacker.characterId,
                 targetCharacterId: target.characterId,
-                damageDealt: damage,
+                damageDealt: damageDealt,
                 manaGained: manaGained);
 
             Functions.CheckVictoryCondition(session);
@@ -186,7 +193,8 @@ namespace RPG_dotnet.Services.GameSessionService
 
             await _context.SaveChangesAsync();
 
-            return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Character attacked successfully");
+            return ServiceResponse<GetGameSessionDto>.Success(
+                _mapper.Map<GetGameSessionDto>(session), "Attack successful");
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> AbandonSessionAsync(int userId, int sessionId)
@@ -217,14 +225,7 @@ namespace RPG_dotnet.Services.GameSessionService
             if (dto.characterIds == null || dto.characterIds.Count != 2)
                 throw new GenericException("Exactly two character IDs must be provided.", 422);
 
-            var characters = await _context.Characters
-                .Where(c => dto.characterIds.Contains(c.id) && c.isPlayable)
-                .ToListAsync();
-
-            if (characters.Count != 2)
-                throw new GenericException("One or more character IDs are invalid.", 422);
-
-            ValidateTeamComposition(characters);
+            var characters = await LoadAndValidateCharactersAsync(dto.characterIds);
 
             foreach (var character in characters)
             {
@@ -241,7 +242,8 @@ namespace RPG_dotnet.Services.GameSessionService
                     isAlive = true,
                     role = character.role,
                     hasActedThisTurn = false,
-                    team = TeamSide.OPPONENT
+                    team = TeamSide.OPPONENT,
+                    reviveCount = character.fighterClass == RpgClass.Berserker ? 1 : 0
                 });
             }
 
@@ -272,10 +274,12 @@ namespace RPG_dotnet.Services.GameSessionService
             return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Session rejected successfully");
         }
 
-        public async Task<ServiceResponse<GetGameSessionDto>> CastSpellAsync(int userId, CastSpellDto dto)
+        public async Task<ServiceResponse<GetGameSessionDto>> CastSpellAsync(
+            int userId, CastSpellDto dto)
         {
             var session = await SessionWithFullIncludes()
-                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
+                .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId
+                                        && gs.state == GameSessionState.ACTIVE)
                 ?? throw new NotFoundException("Game session not found.");
 
             Functions.EnsureUserTurn(session, userId);
@@ -284,22 +288,14 @@ namespace RPG_dotnet.Services.GameSessionService
                 .FirstOrDefault(p => p.characterId == dto.casterId && p.userId == userId)
                 ?? throw new GenericException("Caster not found or not owned by this user.", 422);
 
-            var target = session.participants
-                .FirstOrDefault(p => p.characterId == dto.targetId)
-                ?? throw new GenericException("Target not found.", 422);
-
             if (!caster.isAlive)
                 throw new GenericException("Caster is not alive.", 422);
-
-            if (!target.isAlive)
-                throw new GenericException("Target is not alive.", 422);
 
             if (caster.hasActedThisTurn)
                 throw new GenericException("This character has already acted this turn.", 400);
 
-            if (caster.role == RoleType.Vanguard &&
-                !Functions.IsWithinProximity(caster.xPosition, target.xPosition))
-                throw new GenericException("Vanguard characters can only cast spells on nearby targets.", 422);
+            if (caster.isStunned)
+                throw new GenericException("This character is stunned and cannot act.", 400);
 
             var ability = caster.character.abilities
                 .FirstOrDefault(a => a.id == dto.abilityId)
@@ -308,19 +304,118 @@ namespace RPG_dotnet.Services.GameSessionService
             if (caster.currentMana < ability.manaCost)
                 throw new GenericException("Not enough mana to cast this spell.", 422);
 
-            caster.currentMana -= ability.manaCost;
-            int damage = ability.damage;
-            target.currentHealth = Math.Max(0, target.currentHealth - damage);
-            if (target.currentHealth <= 0) target.isAlive = false;
+            // Validate target ownership matches ability target type
+            SessionCharacterState target = null;
 
+            if (ability.targetType == AbilityTargetType.Ally)
+            {
+                // Heal — must target own team
+                target = session.participants
+                    .FirstOrDefault(p => p.characterId == dto.targetId && p.userId == userId)
+                    ?? throw new GenericException("Heal target must be one of your own characters.", 422);
+            }
+            else if (ability.targetType == AbilityTargetType.Enemy
+                     || ability.targetType == AbilityTargetType.AllEnemies)
+            {
+                // Enemy or MultiTarget — dto.targetId is validated for single
+                // target; MultiTarget fetches all enemies in the switch below
+                target = session.participants
+                    .FirstOrDefault(p => p.characterId == dto.targetId && p.userId != userId)
+                    ?? throw new GenericException("Target not found or is not an enemy.", 422);
+
+                if (!target.isAlive)
+                    throw new GenericException("Target is not alive.", 422);
+
+                // Proximity check: Vanguard casters must be in range UNLESS
+                // the ability is MultiTarget — NP range is not restricted
+                if (caster.role == RoleType.Vanguard
+                    && ability.effect != AbilityEffect.MultiTarget
+                    && !Functions.IsWithinProximity(caster.xPosition, target.xPosition))
+                    throw new GenericException(
+                        "Vanguard characters can only cast spells on nearby targets.", 422);
+            }
+
+            caster.currentMana -= ability.manaCost;
             caster.hasActedThisTurn = true;
+
+            int damageDealt = 0;
+            float? pushedToPosition = null;
+
+            switch (ability.effect)
+            {
+                case AbilityEffect.None:
+                    damageDealt = ApplyDamage(target, ability.damage);
+                    break;
+
+                case AbilityEffect.DefensePierce:
+                    // Gáe Bolg, Tsubame Gaeshi — bypass defense entirely
+                    damageDealt = ApplyDamage(target, ability.damage, pierceDefense: true);
+                    break;
+
+                case AbilityEffect.Heal:
+                    // Garden of Avalon — restore HP to ally, capped at maxHealth
+                    int healAmount = Math.Min(ability.effectValue, target.maxHealth - target.currentHealth);
+                    target.currentHealth += healAmount;
+                    // Log heal amount as negative damage for clarity on frontend
+                    damageDealt = -healAmount;
+                    break;
+
+                case AbilityEffect.ManaDrain:
+                    // Gáe Dearg, Rule Breaker — damage then strip mana
+                    damageDealt = ApplyDamage(target, ability.damage);
+                    if (target.isAlive)
+                        target.currentMana = Math.Max(0, target.currentMana - ability.effectValue);
+                    break;
+
+                case AbilityEffect.Stun:
+                    // Zabaniya — damage then flag target to skip next action
+                    damageDealt = ApplyDamage(target, ability.damage);
+                    if (target.isAlive)
+                        target.isStunned = true;
+                    break;
+
+                case AbilityEffect.Poison:
+                    // All the World's Evil — partial damage now, DoT for 2 turns
+                    damageDealt = ApplyDamage(target, ability.damage);
+                    if (target.isAlive)
+                    {
+                        target.poisonStacks = 2;
+                        target.poisonDamagePerTick = ability.effectValue;
+                    }
+                    break;
+
+                case AbilityEffect.MultiTarget:
+                    // Unlimited Blade Works, Phoebus Catastrophe, Ionioi Hetairoi
+                    // Hit all living enemies regardless of position
+                    var enemies = session.participants
+                        .Where(p => p.userId != userId && p.isAlive)
+                        .ToList();
+                    foreach (var enemy in enemies)
+                        damageDealt += ApplyDamage(enemy, ability.damage);
+                    break;
+
+                case AbilityEffect.PositionPush:
+                    // Bellerophon — damage then push target away
+                    damageDealt = ApplyDamage(target, ability.damage);
+                    if (target.isAlive)
+                    {
+                        target.xPosition = target.team == TeamSide.CREATOR
+                            ? Math.Max(target.xPosition - ability.effectValue, session.minPosition)
+                            : Math.Min(target.xPosition + ability.effectValue, session.maxPosition);
+                        pushedToPosition = target.xPosition;
+                    }
+                    break;
+            }
 
             LogAction(session, GameActionType.CastSpell,
                 actorCharacterId: caster.characterId,
-                targetCharacterId: target.characterId,
+                targetCharacterId: ability.effect == AbilityEffect.MultiTarget
+                    ? null
+                    : target?.characterId,
                 abilityId: ability.id,
-                damageDealt: damage,
-                manaSpent: ability.manaCost);
+                damageDealt: damageDealt,
+                manaSpent: ability.manaCost,
+                newPosition: pushedToPosition);
 
             Functions.CheckVictoryCondition(session);
 
@@ -329,9 +424,12 @@ namespace RPG_dotnet.Services.GameSessionService
 
             await _context.SaveChangesAsync();
 
-            return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Spell cast successfully");
+            return ServiceResponse<GetGameSessionDto>.Success(
+                _mapper.Map<GetGameSessionDto>(session), "Spell cast successfully");
         }
-        public async Task<ServiceResponse<List<GetGameSessionDto>>> GetGameSessionsByUserIdAsync(int userId, GameSessionState? state = null)
+
+        public async Task<ServiceResponse<List<GetGameSessionDto>>> GetGameSessionsByUserIdAsync(
+            int userId, GameSessionState? state = null)
         {
             var query = SessionWithFullIncludes()
                 .Where(gs => gs.creatorUserId == userId || gs.opponentUserId == userId);
@@ -344,14 +442,16 @@ namespace RPG_dotnet.Services.GameSessionService
             if (!sessions.Any())
                 throw new NotFoundException("No game sessions found for the specified user.");
 
-            return ServiceResponse<List<GetGameSessionDto>>.Success(sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList(), "Retrieved game sessions successfully");
+            return ServiceResponse<List<GetGameSessionDto>>.Success(
+                sessions.Select(gs => _mapper.Map<GetGameSessionDto>(gs)).ToList(),
+                "Retrieved game sessions successfully");
         }
 
-        public async Task<ServiceResponse<GetGameSessionDto>> EndTurnAsync(
-            int userId, EndTurnDto dto)
+        public async Task<ServiceResponse<GetGameSessionDto>> EndTurnAsync(int userId, EndTurnDto dto)
         {
             var session = await SessionWithFullIncludes()
-                              .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId && gs.state == GameSessionState.ACTIVE)
+                              .FirstOrDefaultAsync(gs => gs.gameSessionId == dto.sessionId
+                                                         && gs.state == GameSessionState.ACTIVE)
                           ?? throw new NotFoundException("Active session not found.");
 
             Functions.EnsureUserTurn(session, userId);
@@ -363,10 +463,13 @@ namespace RPG_dotnet.Services.GameSessionService
                 actorCharacterId: session.participants.First(p => p.userId == userId).characterId);
 
             Functions.AdvanceTurn(session);
+            ProcessTurnStartEffects(session);
+            Functions.CheckVictoryCondition(session);
 
             await _context.SaveChangesAsync();
 
-            return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Turn ended successfully");
+            return ServiceResponse<GetGameSessionDto>.Success(
+                _mapper.Map<GetGameSessionDto>(session), "Turn ended successfully");
         }
 
         private IQueryable<GameSession> SessionWithFullIncludes() =>
@@ -407,6 +510,76 @@ namespace RPG_dotnet.Services.GameSessionService
             });
         }
 
+        private static int ApplyDamage(
+            SessionCharacterState target,
+            int rawDamage,
+            bool pierceDefense = false)
+        {
+            int effectiveDamage = pierceDefense
+                ? rawDamage
+                : Math.Max(1, rawDamage - target.character.defense / 2);
+
+            target.currentHealth = Math.Max(0, target.currentHealth - effectiveDamage);
+
+            if (target.currentHealth <= 0)
+            {
+                // Heracles passive: reviveCount > 0 means God Hand intercepts death
+                if (target.reviveCount > 0)
+                {
+                    target.currentHealth = 30;
+                    target.reviveCount--;
+                }
+                else
+                {
+                    target.isAlive = false;
+                }
+            }
+
+            return effectiveDamage;
+        }
+
+        private static void ProcessTurnStartEffects(GameSession session)
+        {
+            var incoming = session.participants
+                .Where(p => p.userId == session.currentTurnPlayerId && p.isAlive)
+                .ToList();
+
+            foreach (var p in incoming)
+            {
+                if (p.isStunned)
+                {
+                    p.hasActedThisTurn = true; // forces the character to skip
+                    p.isStunned = false;
+                }
+
+                if (p.poisonStacks > 0)
+                {
+                    p.currentHealth = Math.Max(0, p.currentHealth - p.poisonDamagePerTick);
+                    p.poisonStacks--;
+
+                    if (p.currentHealth <= 0)
+                    {
+                        if (p.reviveCount > 0)
+                        {
+                            p.currentHealth = 30;
+                            p.reviveCount--;
+                        }
+                        else
+                        {
+                            p.isAlive = false;
+                        }
+                    }
+
+                    if (p.poisonStacks == 0)
+                        p.poisonDamagePerTick = 0;
+                }
+            }
+        }
+
+        // Only advances the turn once all of the current player's alive
+        // characters have acted. After switching, immediately processes
+        // status effects on the incoming player and checks for victory
+        // in case poison killed someone on the turn boundary.
         private static void TryAdvanceTurn(GameSession session, int userId)
         {
             bool allActed = session.participants
@@ -414,7 +587,11 @@ namespace RPG_dotnet.Services.GameSessionService
                 .All(p => p.hasActedThisTurn);
 
             if (allActed)
+            {
                 Functions.AdvanceTurn(session);
+                ProcessTurnStartEffects(session);
+                Functions.CheckVictoryCondition(session);
+            }
         }
 
         private static void ValidateTeamComposition(List<Characters> characters)
@@ -425,6 +602,28 @@ namespace RPG_dotnet.Services.GameSessionService
             if (!hasSupport || !hasVanguard)
                 throw new GenericException(
                     "A valid team must consist of one Support and one Vanguard character.", 422);
+        }
+
+        // Shared character validation used by both Create and Accept.
+        // Checks IDs exist AND that all selected characters are available
+        // for play — isPlayable = false means the character is in the DB
+        // but locked (balancing, unreleased, etc).
+        private async Task<List<Characters>> LoadAndValidateCharactersAsync(List<int> characterIds)
+        {
+            var characters = await _context.Characters
+                .Where(c => characterIds.Contains(c.id))
+                .ToListAsync();
+
+            if (characters.Count != characterIds.Count)
+                throw new GenericException("One or more character IDs are invalid.", 422);
+
+            if (characters.Any(c => !c.isPlayable))
+                throw new GenericException(
+                    "One or more selected characters are not currently available for play.", 422);
+
+            ValidateTeamComposition(characters);
+
+            return characters;
         }
 
     }

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -25,7 +25,7 @@ namespace RPG_dotnet.Services.GameSessionService
                 throw new GenericException("Exactly two character IDs must be provided.", 422);
 
             var characters = await _context.Characters
-                .Where(c => newSessionDto.characterIds.Contains(c.id))
+                .Where(c => newSessionDto.characterIds.Contains(c.id) && c.isPlayable)
                 .ToListAsync();
 
             if (characters.Count != 2)
@@ -218,7 +218,7 @@ namespace RPG_dotnet.Services.GameSessionService
                 throw new GenericException("Exactly two character IDs must be provided.", 422);
 
             var characters = await _context.Characters
-                .Where(c => dto.characterIds.Contains(c.id))
+                .Where(c => dto.characterIds.Contains(c.id) && c.isPlayable)
                 .ToListAsync();
 
             if (characters.Count != 2)


### PR DESCRIPTION
### Short Description
Heroic Spirits roster with Noble Phantasm effects, support ranged attack rework, and session creation username fix.

### Details
**What did you change?**
- Added 14 playable Heroic Spirits across 8 classes (Saber, Archer, Lancer, Rider, Caster, Assassin, Berserker, Avenger)
- Added two Noble Phantasms per character with distinct effect types: `None`, `Heal`, `ManaDrain`, `Stun`, `Poison`, `MultiTarget`, `DefensePierce`, `PositionPush`
- Added `Revive` passive mechanic on `SessionCharacterState` — seeded on Heracles (God Hand)
- Added `AbilityEffect` and `AbilityTargetType` enums to `RpgClass.cs`
- Extended `Ability` model with `effect`, `effectValue`, `targetType`
- Extended `Characters` model with `description` and `isPlayable`
- Extended `SessionCharacterState` with `isStunned`, `poisonStacks`, `poisonDamagePerTick`, `reviveCount`
- Rewrote `CastSpellAsync` with a full effect switch handling all NP effect types
- Added `ApplyDamage` helper with optional `pierceDefense` flag and God Hand intercept
- Added `ProcessTurnStartEffects` — ticks poison and clears stun at turn start after `AdvanceTurn`
- Added `LoadAndValidateCharactersAsync` — shared validation enforcing `isPlayable` on session creation and acceptance
- Removed Support basic attack restriction — Support characters now attack from range without proximity check
- Fixed `CreateGameSessionAsync` to re-fetch through `SessionWithFullIncludes` after save, resolving null `creatorUsername` and `opponentUsername` in the creation response
- Added `heroic_spirits_seed.sql` — idempotent seed script for all 14 characters and 28 Noble Phantasms

**Why did you make the change?**
- The game needed actual characters grounded in the Fate series rather than user-created ones, with admin-only character management via `isPlayable` gating
- Noble Phantasm effects make each character strategically distinct — without them every NP was just a bigger number
- God Hand gives Heracles a meaningful passive that reflects his lore without requiring a separate mechanic
- Poison and Stun create multi-turn strategic depth that basic damage cannot
- Support characters being unable to basic attack meant they generated no mana and were completely passive for the first several turns, breaking the intended game loop — Archers and Casters are ranged attackers by design
- `creatorUsername` and `opponentUsername` were null on session creation because AutoMapper was mapping from an in-memory object that had not loaded the user navigation properties

**Type of change:**
- [x] New feature or functionality added
- [x] Fixing a bug or issue in existing functionality