### PR TITLE
feature: add directional movement for Vanguard characters

### DIFF
--- a/Dtos/GameSession/MoveActionDto.cs
+++ b/Dtos/GameSession/MoveActionDto.cs
@@ -9,6 +9,6 @@ namespace RPG_dotnet.Dtos.GameSession
     {
         public int sessionId { get; set; }
         public int characterId { get; set; }
-        public float newPosition { get; set; }
+        public MoveDirection direction { get; set; } = MoveDirection.Forward;
     }
 }

--- a/Models/RpgClass.cs
+++ b/Models/RpgClass.cs
@@ -62,4 +62,11 @@ namespace RPG_dotnet.Models
         Ally,
         AllEnemies
     }
+
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum MoveDirection
+    {
+        Forward,
+        Backward
+    }
 }

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -116,9 +116,20 @@ namespace RPG_dotnet.Services.GameSessionService
             if (character.isStunned)
                 throw new GenericException("This character is stunned and cannot act.", 400);
 
-            float newPos = character.team == TeamSide.CREATOR
-                ? Math.Min(character.xPosition + character.character.movement, session.maxPosition)
-                : Math.Max(character.xPosition - character.character.movement, session.minPosition);
+            float newPos;
+
+            if (dto.direction == MoveDirection.Forward)
+            {
+                newPos = character.team == TeamSide.CREATOR
+                    ? Math.Min(character.xPosition + character.character.movement, session.maxPosition)
+                    : Math.Max(character.xPosition - character.character.movement, session.minPosition);
+            }
+            else
+            {
+                newPos = character.team == TeamSide.CREATOR
+                    ? Math.Max(character.xPosition - character.character.movement, session.minPosition)
+                    : Math.Min(character.xPosition + character.character.movement, session.maxPosition);
+            }
 
             character.xPosition = newPos;
             character.hasActedThisTurn = true;


### PR DESCRIPTION
### Short Description
Adds forward and backward directional movement, enabling tactical repositioning and Support diving strategies.

### Details
**What did you change?**
- Added `MoveDirection` enum (`Forward`, `Backward`) to `RpgClass.cs`
- Extended `MoveActionDto` with a `direction` field defaulting to `Forward`
- Reworked position calculation in `MoveCharacterAsync` to respect the chosen direction relative to each team's starting side — Creator moves right to advance and left to retreat, Opponent moves left to advance and right to retreat

**Why did you make the change?**
- Previously Vanguards were locked to a single direction based on their team side, making it impossible to retreat, kite, or bypass the enemy Vanguard to target the opposing Support
- Backward movement opens up meaningful tactical decisions — a Vanguard can let the enemy pass and go straight for their backline Support, or retreat to protect their own Support when under pressure
- Default of `Forward` preserves existing behaviour for any client that sends no direction

**Type of change:**
- [x] New feature or functionality added
- [ ] Fixing a bug or issue in existing functionality

