### PR TITLE
feature/signalr

### DIFF
--- a/Hubs/GameSessionHub.cs
+++ b/Hubs/GameSessionHub.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace RPG_dotnet.Hubs;
+
+    [Authorize]
+    public class GameSessionHub : Hub<IGameSessionClient>
+    {
+        private readonly DataContext _context;
+
+        public GameSessionHub(DataContext context)
+        {
+            _context = context;
+        }
+
+        public async Task JoinSession(int sessionId)
+        {
+            var userId = GetUserId();
+            var isParticipant = await _context.GameSessions
+                .AnyAsync(gs => gs.gameSessionId == sessionId &&
+                               (gs.creatorUserId == userId || gs.opponentUserId == userId));
+
+            if (!isParticipant)
+            {
+                await Clients.Caller.Error("You are not a participant in this session.");
+                return;
+            }
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, GroupName(sessionId));
+        }
+
+        public async Task LeaveSession(int sessionId)
+        {
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName(sessionId));
+        }
+
+        public override async Task OnDisconnectedAsync(Exception? exception)
+        {
+            await base.OnDisconnectedAsync(exception);
+        }
+
+        public static string GroupName(int sessionId) => $"session-{sessionId}";
+
+        private int GetUserId()
+        {
+            var claim = Context.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
+            if (claim == null)
+                throw new HubException("Unauthorised.");
+            return int.Parse(claim.Value);
+        }
+    }

--- a/Hubs/IGameSessionClient.cs
+++ b/Hubs/IGameSessionClient.cs
@@ -1,0 +1,8 @@
+namespace RPG_dotnet.Hubs;
+
+public interface IGameSessionClient
+{
+    Task SessionUpdated(GetGameSessionDto session);
+    Task SessionCompleted(GetGameSessionDto session);
+    Task Error(string message);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -39,6 +39,7 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.Elasticsearch;
 using Serilog.Sinks.File;
+using RPG_dotnet.Hubs;
 
 var builder = WebApplication.CreateBuilder(args);
 DotEnv.Load();
@@ -75,6 +76,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IGameSessionService, GameSessionService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<AllowUnauthenticatedAttribute>();
+builder.Services.AddSignalR();
 builder.Services.AddValidatorsFromAssemblyContaining<CreateCharacterReqValidator>();
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -92,7 +94,21 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             OnChallenge = async context =>
             {
                 await Task.Run(() => throw new AuthException());
+            },
+            OnMessageReceived = context =>
+            {
+                var accessToken = context.Request.Query["access_token"];
+                var path = context.HttpContext.Request.Path;
+
+                if (!string.IsNullOrEmpty(accessToken) &&
+                    path.StartsWithSegments("/hubs/gamesession"))
+                {
+                    context.Token = accessToken;
+                }
+
+                return Task.CompletedTask;
             }
+
         };
     });
 Log.Logger = new LoggerConfiguration()
@@ -153,5 +169,6 @@ app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+app.MapHub<GameSessionHub>("/hubs/gamesession");
 
 app.Run();

--- a/RPG-dotnet.csproj
+++ b/RPG-dotnet.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -5,6 +5,8 @@ using RPG_dotnet.Models;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using RPG_dotnet.Hubs;
 
 namespace RPG_dotnet.Services.GameSessionService
 {
@@ -12,11 +14,13 @@ namespace RPG_dotnet.Services.GameSessionService
     {
         private readonly IMapper _mapper;
         private readonly DataContext _context;
+        private readonly IHubContext<GameSessionHub, IGameSessionClient> _hub;
 
-        public GameSessionService(DataContext context, IMapper mapper)
+        public GameSessionService(DataContext context, IMapper mapper, IHubContext<GameSessionHub, IGameSessionClient> hub)
         {
             _context = context;
             _mapper = mapper;
+            _hub = hub;
         }
 
         public async Task<ServiceResponse<GetGameSessionDto>> CreateGameSessionAsync(
@@ -65,6 +69,8 @@ namespace RPG_dotnet.Services.GameSessionService
 
             var created = await SessionWithFullIncludes()
                 .FirstAsync(gs => gs.gameSessionId == session.gameSessionId);
+
+            await PushSessionUpdate(created);
 
             return ServiceResponse<GetGameSessionDto>.Success(
                 _mapper.Map<GetGameSessionDto>(created), "Created new session successfully");
@@ -138,6 +144,7 @@ namespace RPG_dotnet.Services.GameSessionService
             TryAdvanceTurn(session, userId);
 
             await _context.SaveChangesAsync();
+            await PushSessionUpdate(session);
 
             return ServiceResponse<GetGameSessionDto>.Success(
                 _mapper.Map<GetGameSessionDto>(session), "Character moved successfully");
@@ -203,6 +210,7 @@ namespace RPG_dotnet.Services.GameSessionService
                 TryAdvanceTurn(session, userId);
 
             await _context.SaveChangesAsync();
+            await PushSessionUpdate(session);
 
             return ServiceResponse<GetGameSessionDto>.Success(
                 _mapper.Map<GetGameSessionDto>(session), "Attack successful");
@@ -220,6 +228,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             session.state = GameSessionState.ABANDONED;
             await _context.SaveChangesAsync();
+            await PushSessionUpdate(session);
 
             return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Session abandoned successfully");
         }
@@ -266,6 +275,7 @@ namespace RPG_dotnet.Services.GameSessionService
             session.state = GameSessionState.ACTIVE;
 
             await _context.SaveChangesAsync();
+            await PushSessionUpdate(session);
 
             return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Session accepted successfully");
         }
@@ -281,6 +291,7 @@ namespace RPG_dotnet.Services.GameSessionService
 
             session.state = GameSessionState.REJECTED;
             await _context.SaveChangesAsync();
+            await PushSessionUpdate(session);
 
             return ServiceResponse<GetGameSessionDto>.Success(_mapper.Map<GetGameSessionDto>(session), "Session rejected successfully");
         }
@@ -434,6 +445,7 @@ namespace RPG_dotnet.Services.GameSessionService
                 TryAdvanceTurn(session, userId);
 
             await _context.SaveChangesAsync();
+            await PushSessionUpdate(session);
 
             return ServiceResponse<GetGameSessionDto>.Success(
                 _mapper.Map<GetGameSessionDto>(session), "Spell cast successfully");
@@ -478,6 +490,7 @@ namespace RPG_dotnet.Services.GameSessionService
             Functions.CheckVictoryCondition(session);
 
             await _context.SaveChangesAsync();
+            await PushSessionUpdate(session);
 
             return ServiceResponse<GetGameSessionDto>.Success(
                 _mapper.Map<GetGameSessionDto>(session), "Turn ended successfully");
@@ -635,6 +648,17 @@ namespace RPG_dotnet.Services.GameSessionService
             ValidateTeamComposition(characters);
 
             return characters;
+        }
+
+        private async Task PushSessionUpdate(GameSession session)
+        {
+            var dto = _mapper.Map<GetGameSessionDto>(session);
+            var group = GameSessionHub.GroupName(session.gameSessionId);
+
+            if (session.state == GameSessionState.COMPLETED)
+                await _hub.Clients.Group(group).SessionCompleted(dto);
+            else
+                await _hub.Clients.Group(group).SessionUpdated(dto);
         }
 
     }


### PR DESCRIPTION
### Short Description
Adds SignalR real-time push so both players receive session updates instantly after every action without polling.

### Details
**What did you change?**
- Added `IGameSessionClient` — strongly typed interface defining server-to-client push methods (`SessionUpdated`, `SessionCompleted`, `Error`)
- Added `GameSessionHub` — SignalR hub with `JoinSession` and `LeaveSession` methods. Players join a group keyed by `session-{sessionId}` and receive all pushes for that session. Participant validation on join prevents eavesdropping
- Added `PushSessionUpdate` helper to `GameSessionService` — maps the session to `GetGameSessionDto` and broadcasts to the session group after every `SaveChangesAsync`. Routes to `SessionCompleted` when state is `COMPLETED` so the frontend can navigate to results without checking state
- Injected `IHubContext<GameSessionHub, IGameSessionClient>` into `GameSessionService` constructor
- Registered `AddSignalR()` in `Program.cs` and mapped the hub at `/hubs/gamesession`
- Added `OnMessageReceived` to `JwtBearerEvents` to extract the token from the `access_token` query parameter — required because browsers cannot set custom headers during WebSocket handshake

**Why did you make the change?**
- Polling is a poor experience for a turn-based game — players would need to repeatedly call `GET /GameSession/{id}` to detect when the opponent has acted. SignalR eliminates the delay and the wasted requests
- Both players now see the updated board state the moment an action resolves, making the game feel live
- `SessionCompleted` as a separate push event means the frontend never needs to inspect `state` after the fact — it receives an unambiguous signal to navigate away

**Type of change:**
- [x] New feature or functionality added