### PR TITLE
fix: optional Elasticsearch sink and configurable CORS

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -48,8 +48,11 @@ string token = Environment.GetEnvironmentVariable("TOKEN");
 string esUri = Environment.GetEnvironmentVariable("ELASTIC_URI");
 string esUsername = Environment.GetEnvironmentVariable("ELASTIC_USERNAME");
 string esPassword = Environment.GetEnvironmentVariable("ELASTIC_PASSWORD");
-if (connString is null || token is null || esUri is null || esUsername is null || esPassword is null)
+string corsOrigins = Environment.GetEnvironmentVariable("CORS_ALLOWED_ORIGINS");
+if (connString is null || token is null)
     throw new NotFoundException("Missing environment variables");
+// Elasticsearch is optional so local dev can run without a cluster
+bool elasticConfigured = esUri is not null && esUsername is not null && esPassword is not null;
 // Add services to the container.
 builder.Services.AddDbContext<DataContext>(options =>
 options.UseSqlServer(connString));
@@ -111,7 +114,28 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
         };
     });
-Log.Logger = new LoggerConfiguration()
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        if (!string.IsNullOrWhiteSpace(corsOrigins))
+        {
+            policy.WithOrigins(corsOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        }
+        else
+        {
+            // No origins configured: allow everything (credentials included, needed by SignalR)
+            policy.SetIsOriginAllowed(_ => true)
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        }
+    });
+});
+var loggerConfiguration = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .MinimumLevel.Information()
     // --- Start Overrides to reduce clutter from Microsoft and EF Core ---
@@ -135,8 +159,11 @@ Log.Logger = new LoggerConfiguration()
     // .MinimumLevel.Override("Microsoft.AspNetCore.Routing.EndpointMiddleware", LogEventLevel.Warning) // For "Executing endpoint"
 
 
-    .WriteTo.Console(new ElasticsearchJsonFormatter())
-    .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(esUri))
+    .WriteTo.Console(new ElasticsearchJsonFormatter());
+
+if (elasticConfigured)
+{
+    loggerConfiguration.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(esUri))
     {
         AutoRegisterTemplate = false,
         IndexFormat = "dotnet-app-logs-{0:yyyy.MM}",
@@ -147,8 +174,13 @@ Log.Logger = new LoggerConfiguration()
         EmitEventFailure = EmitEventFailureHandling.WriteToSelfLog |
                            EmitEventFailureHandling.WriteToFailureSink |
                            EmitEventFailureHandling.ThrowException
-    })
-    .CreateLogger();
+    });
+}
+
+Log.Logger = loggerConfiguration.CreateLogger();
+
+if (!elasticConfigured)
+    Log.Warning("Elasticsearch environment variables not set, logging to console only");
 
 builder.Services.AddSingleton(Log.Logger);
 
@@ -163,6 +195,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseCors();
 app.UseCorrelationId();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 //not needed for now app.UseHttpsRedirection();


### PR DESCRIPTION
## What changed

- **Elasticsearch is now optional at boot.** Only `DB_CONNECTION_STRING` and `TOKEN` are required. The Serilog Elasticsearch sink is attached only when `ELASTIC_URI`, `ELASTIC_USERNAME` and `ELASTIC_PASSWORD` are all set; otherwise the app falls back to console-only logging and emits a warning at startup.
- **Added CORS support.** There was previously no CORS registration, so browser frontends (including the SignalR hub client) were blocked. A default policy is now applied early in the pipeline (ahead of the exception middleware, so error responses also carry the headers):
  - `CORS_ALLOWED_ORIGINS` set (comma-separated): only those origins are allowed, with any header/method and credentials (needed by the SignalR browser client).
  - Unset: all origins allowed, for friction-free local dev.

## Why

Local development previously required a reachable Elasticsearch cluster and its credentials just to start the API, and any browser-based frontend could not call the API at all due to missing CORS headers.

## Notes for reviewers

- Verified by booting without ES vars (clean start, warning logged) and by exercising preflight requests: with `CORS_ALLOWED_ORIGINS` set, a listed origin receives the `Access-Control-Allow-*` headers and an unlisted origin receives none.
- The no-env-var fallback is intentionally wide open; set `CORS_ALLOWED_ORIGINS` on Render once the frontend URL is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
