### PR TITLE
fix: solution build broken by test project globbing

### DIFF
--- a/Fate-Phantasm-BW-Ghost-touch.sln
+++ b/Fate-Phantasm-BW-Ghost-touch.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RPG-dotnet", "RPG-dotnet.csproj", "{3C5C2605-26AA-55D7-B025-38074A3278C6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RPG-dotnet.Tests", "RPG-dotnet.Tests\RPG-dotnet.Tests.csproj", "{98BF564E-37A5-83AD-8937-D2D40D981CC0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3C5C2605-26AA-55D7-B025-38074A3278C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C5C2605-26AA-55D7-B025-38074A3278C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C5C2605-26AA-55D7-B025-38074A3278C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C5C2605-26AA-55D7-B025-38074A3278C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98BF564E-37A5-83AD-8937-D2D40D981CC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98BF564E-37A5-83AD-8937-D2D40D981CC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98BF564E-37A5-83AD-8937-D2D40D981CC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98BF564E-37A5-83AD-8937-D2D40D981CC0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {53067FE0-D90E-4B13-9AF6-CB837BF09477}
+	EndGlobalSection
+EndGlobal

--- a/RPG-dotnet.Tests/RPG-dotnet.Tests.csproj
+++ b/RPG-dotnet.Tests/RPG-dotnet.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RPG-dotnet.csproj
+++ b/RPG-dotnet.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>RPG_dotnet</RootNamespace>
+    <!-- The test project lives in a subfolder; keep its sources out of this project's compile glob -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);RPG-dotnet.Tests/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +28,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SQLServer" Version="9.0.5" />
-    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Formatting.Elasticsearch" Version="10.0.0" />
@@ -35,8 +36,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="Xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Exclude `RPG-dotnet.Tests/**` from the web project's default compile glob. The root-level csproj was compiling the test project's sources and generated `obj/` AssemblyInfo files, causing duplicate-attribute errors (CS0579) on solution builds and a `Microsoft.NET.Test.Sdk` downgrade conflict (NU1605) in the test project.
- Move test-only packages (`Xunit`, `Moq`, `Microsoft.NET.Test.Sdk`) out of the web project; add `Moq` to the test project where it is actually used.
- Track the previously untracked `Fate-Phantasm-BW-Ghost-touch.sln` so solution-level builds and test discovery work from a fresh clone.

## Verification
- Test project and web project both build with 0 errors, including with the test project's `obj/` files present (the case that previously failed).
- `dotnet test`: 2/2 passing.
- App starts and serves on http://localhost:5018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)