### PR TITLE
fix: resolve MSB1011 ambiguous project/solution in Docker and CI builds

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,12 +23,14 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{matrix.dotnet-version}}
+      # Target the solution explicitly: the repo root contains both a
+      # solution and a project file, so bare dotnet commands are ambiguous
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore Fate-Phantasm-BW-Ghost-touch.sln
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build Fate-Phantasm-BW-Ghost-touch.sln --no-restore
       - name: Test
-        run: dotnet test --verbosity normal
+        run: dotnet test Fate-Phantasm-BW-Ghost-touch.sln --verbosity normal
      # - name: Configure AWS CLI
       #  run: |
        #   aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ WORKDIR /app
 # Copy everything (including .csproj and solution)
 COPY . ./
 
-# Restore packages
-RUN dotnet restore
+# Restore packages (target the web project explicitly: the root contains
+# both a solution and a project file, so a bare restore is ambiguous)
+RUN dotnet restore RPG-dotnet.csproj
 
 # Build and publish
-RUN dotnet publish -c Release -o /app/out
+RUN dotnet publish RPG-dotnet.csproj -c Release -o /app/out
 
 # ---- Runtime Stage ----
 FROM mcr.microsoft.com/dotnet/aspnet:8.0


### PR DESCRIPTION
### Short Description
Fixes the Docker and CI build failure `MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.`

### Details

**What did you change?**
- Dockerfile: `dotnet restore` and `dotnet publish` now target `RPG-dotnet.csproj` explicitly
- CI workflow (`dotnet.yml`): restore, build and test now target `Fate-Phantasm-BW-Ghost-touch.sln` explicitly

**Why did you make the change?**
- Since the solution file was added to the repo root (a3bd8ca), the root contains both a `.sln` and a `.csproj`, so bare `dotnet` commands fail with MSB1011. This broke the Docker image build and would break the CI restore step for the same reason.

**Type of change:**

_Tick one below._
- [ ] New feature or functionality added
- [x] Fixing a bug or issue in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)