### PR TITLE
Auto-skip dead turns when the incoming player cannot act

### DIFF
--- a/RPG-dotnet.Tests/Services/GameSessionServiceTurnEngineTests.cs
+++ b/RPG-dotnet.Tests/Services/GameSessionServiceTurnEngineTests.cs
@@ -1,0 +1,191 @@
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using RPG_dotnet;
+using RPG_dotnet.Data;
+using RPG_dotnet.Dtos.GameSession;
+using RPG_dotnet.Hubs;
+using RPG_dotnet.Models;
+using RPG_dotnet.Services.GameSessionService;
+using Xunit;
+
+namespace RPG_dotnet.Tests.Services;
+
+// Covers the auto-skip behaviour of the turn engine: when the incoming
+// player has no living character able to act (typically because every
+// survivor was stunned), the server should end that dead turn itself
+// rather than stranding the player, while never looping forever.
+public class GameSessionServiceTurnEngineTests
+{
+    private const int UserA = 1;
+    private const int UserB = 2;
+
+    private readonly DataContext _context;
+    private readonly IGameSessionService _service;
+
+    public GameSessionServiceTurnEngineTests()
+    {
+        var options = new DbContextOptionsBuilder<DataContext>()
+            // Unique name per instance so parallel test classes never share state.
+            .UseInMemoryDatabase(databaseName: $"TurnEngineTests_{System.Guid.NewGuid()}")
+            .Options;
+        _context = new DataContext(options);
+        _context.Database.EnsureCreated();
+
+        var mapper = new MapperConfiguration(cfg => cfg.AddProfile(new AutoMapperProfile()))
+            .CreateMapper();
+
+        // The hub is only used to broadcast updates; stub it so awaits complete.
+        var clientProxy = new Mock<IGameSessionClient>();
+        clientProxy.Setup(c => c.SessionUpdated(It.IsAny<GetGameSessionDto>()))
+            .Returns(Task.CompletedTask);
+        clientProxy.Setup(c => c.SessionCompleted(It.IsAny<GetGameSessionDto>()))
+            .Returns(Task.CompletedTask);
+
+        var hubClients = new Mock<IHubClients<IGameSessionClient>>();
+        hubClients.Setup(c => c.Group(It.IsAny<string>())).Returns(clientProxy.Object);
+
+        var hub = new Mock<IHubContext<GameSessionHub, IGameSessionClient>>();
+        hub.Setup(h => h.Clients).Returns(hubClients.Object);
+
+        _service = new GameSessionService(_context, mapper, hub.Object);
+    }
+
+    // Builds an ACTIVE two-player session where it is UserA's turn. Each side
+    // gets a single character; the callers tweak the resulting participant
+    // states (stun, poison, etc.) before acting.
+    private GameSession SeedSession(
+        System.Action<SessionCharacterState>? configureA = null,
+        System.Action<SessionCharacterState>? configureB = null)
+    {
+        _context.Users.AddRange(
+            new User { id = UserA, userName = "playerA" },
+            new User { id = UserB, userName = "playerB" });
+
+        var charA = new Characters { id = 1, name = "CharA", isPlayable = true };
+        var charB = new Characters { id = 2, name = "CharB", isPlayable = true };
+        _context.Characters.AddRange(charA, charB);
+
+        var pA = new SessionCharacterState
+        {
+            characterId = charA.id,
+            userId = UserA,
+            currentHealth = 100,
+            maxHealth = 100,
+            currentMana = 10,
+            maxMana = 20,
+            isAlive = true,
+            role = RoleType.Vanguard,
+            team = TeamSide.CREATOR,
+            hasActedThisTurn = false
+        };
+        var pB = new SessionCharacterState
+        {
+            characterId = charB.id,
+            userId = UserB,
+            currentHealth = 100,
+            maxHealth = 100,
+            currentMana = 10,
+            maxMana = 20,
+            isAlive = true,
+            role = RoleType.Vanguard,
+            team = TeamSide.OPPONENT,
+            hasActedThisTurn = false
+        };
+
+        configureA?.Invoke(pA);
+        configureB?.Invoke(pB);
+
+        var session = new GameSession
+        {
+            creatorUserId = UserA,
+            opponentUserId = UserB,
+            currentTurnPlayerId = UserA,
+            state = GameSessionState.ACTIVE,
+            currentTurnIndex = 0,
+            participants = { pA, pB }
+        };
+
+        _context.GameSessions.Add(session);
+        _context.SaveChanges();
+        return session;
+    }
+
+    [Fact]
+    public async Task EndTurn_WhenOnlySurvivorIsStunned_AutoSkipsBackToActingPlayer()
+    {
+        var session = SeedSession(configureB: b => b.isStunned = true);
+
+        await _service.EndTurnAsync(UserA, new EndTurnDto { sessionId = session.gameSessionId });
+
+        var reloaded = await _context.GameSessions
+            .Include(gs => gs.participants)
+            .Include(gs => gs.actionLog)
+            .FirstAsync(gs => gs.gameSessionId == session.gameSessionId);
+
+        // B's dead turn was auto-skipped, so control is back with A.
+        Assert.Equal(UserA, reloaded.currentTurnPlayerId);
+
+        // The stun was consumed at B's (skipped) turn boundary.
+        var charB = reloaded.participants.Single(p => p.userId == UserB);
+        Assert.False(charB.isStunned);
+
+        // The skipped turn was recorded against B's character for traceability.
+        Assert.Contains(reloaded.actionLog,
+            log => log.actionType == GameActionType.EndTurn && log.actorCharacterId == 2);
+    }
+
+    [Fact]
+    public async Task EndTurn_WhenBothSidesAreStunned_DoesNotLoopForever()
+    {
+        var session = SeedSession(
+            configureA: a => a.isStunned = true,
+            configureB: b => b.isStunned = true);
+
+        // If the skip loop were unbounded this call would never return.
+        await _service.EndTurnAsync(UserA, new EndTurnDto { sessionId = session.gameSessionId });
+
+        var reloaded = await _context.GameSessions
+            .Include(gs => gs.participants)
+            .Include(gs => gs.actionLog)
+            .FirstAsync(gs => gs.gameSessionId == session.gameSessionId);
+
+        // The game is still in progress and settled on a real player.
+        Assert.Equal(GameSessionState.ACTIVE, reloaded.state);
+        Assert.Contains(reloaded.currentTurnPlayerId, new[] { UserA, UserB });
+
+        // Both stuns were consumed rather than lingering.
+        Assert.All(reloaded.participants, p => Assert.False(p.isStunned));
+
+        // Auto-skips are bounded: one manual EndTurn plus at most one skip per
+        // player. Guards against a silent runaway loop that still terminates.
+        var endTurns = reloaded.actionLog.Count(log => log.actionType == GameActionType.EndTurn);
+        Assert.True(endTurns <= 3, $"Expected a bounded number of EndTurn logs, got {endTurns}.");
+    }
+
+    [Fact]
+    public async Task EndTurn_WhenSkippedTurnCharacterIsPoisoned_PoisonStillTicks()
+    {
+        var session = SeedSession(configureB: b =>
+        {
+            b.isStunned = true;
+            b.poisonStacks = 2;
+            b.poisonDamagePerTick = 5;
+            b.currentHealth = 100;
+        });
+
+        await _service.EndTurnAsync(UserA, new EndTurnDto { sessionId = session.gameSessionId });
+
+        var charB = await _context.SessionCharacterStates
+            .FirstAsync(p => p.userId == UserB);
+
+        // Poison applied exactly once as B's turn started, even though the turn
+        // was auto-skipped due to the stun.
+        Assert.Equal(95, charB.currentHealth);
+        Assert.Equal(1, charB.poisonStacks);
+        Assert.False(charB.isStunned);
+    }
+}

--- a/Services/GameSessionService/GameSessionService.cs
+++ b/Services/GameSessionService/GameSessionService.cs
@@ -485,9 +485,7 @@ namespace RPG_dotnet.Services.GameSessionService
             LogAction(session, GameActionType.EndTurn,
                 actorCharacterId: session.participants.First(p => p.userId == userId).characterId);
 
-            Functions.AdvanceTurn(session);
-            ProcessTurnStartEffects(session);
-            Functions.CheckVictoryCondition(session);
+            AdvanceTurnAndProcess(session);
 
             await _context.SaveChangesAsync();
             await PushSessionUpdate(session);
@@ -601,9 +599,9 @@ namespace RPG_dotnet.Services.GameSessionService
         }
 
         // Only advances the turn once all of the current player's alive
-        // characters have acted. After switching, immediately processes
-        // status effects on the incoming player and checks for victory
-        // in case poison killed someone on the turn boundary.
+        // characters have acted. The actual switch, status-effect
+        // processing and dead-turn skipping is delegated to
+        // AdvanceTurnAndProcess.
         private static void TryAdvanceTurn(GameSession session, int userId)
         {
             bool allActed = session.participants
@@ -611,7 +609,60 @@ namespace RPG_dotnet.Services.GameSessionService
                 .All(p => p.hasActedThisTurn);
 
             if (allActed)
+                AdvanceTurnAndProcess(session);
+        }
+
+        // Switches to the next player, applies their start-of-turn status
+        // effects (poison ticks, stun expiry) and checks for victory in case
+        // poison killed someone on the turn boundary.
+        //
+        // If the incoming player is left with no living character able to act
+        // — e.g. every survivor was stunned this turn — the server would
+        // otherwise hand them a dead turn it never ends, forcing a manual
+        // endturn call. Instead we log an automatic EndTurn for traceability
+        // and advance again.
+        //
+        // The skip loop is bounded two ways so that a state where BOTH players
+        // are fully incapacitated cannot spin forever: we stop as soon as
+        // control returns to the player we started from, and never iterate
+        // more than once per distinct player regardless.
+        private static void AdvanceTurnAndProcess(GameSession session)
+        {
+            int startingPlayerId = session.currentTurnPlayerId;
+            int playerCount = session.participants
+                .Select(p => p.userId)
+                .Distinct()
+                .Count();
+
+            Functions.AdvanceTurn(session);
+            ProcessTurnStartEffects(session);
+            Functions.CheckVictoryCondition(session);
+
+            for (int skips = 0;
+                 skips < playerCount && session.state == GameSessionState.ACTIVE;
+                 skips++)
             {
+                // A full lap back to whoever we started from without finding an
+                // able player: stop and let them resolve it manually rather
+                // than risk looping.
+                if (session.currentTurnPlayerId == startingPlayerId)
+                    break;
+
+                var incoming = session.participants
+                    .Where(p => p.userId == session.currentTurnPlayerId && p.isAlive)
+                    .ToList();
+
+                // At least one living character can still act — hand over a
+                // real turn.
+                if (incoming.Any(p => !p.hasActedThisTurn))
+                    break;
+
+                // No living character can act: auto-end this turn (when there is
+                // someone to attribute the log to) and advance to the next player.
+                if (incoming.Count > 0)
+                    LogAction(session, GameActionType.EndTurn,
+                        actorCharacterId: incoming.First().characterId);
+
                 Functions.AdvanceTurn(session);
                 ProcessTurnStartEffects(session);
                 Functions.CheckVictoryCondition(session);


### PR DESCRIPTION
## What changed

The turn engine's `ProcessTurnStartEffects` marks stunned characters `hasActedThisTurn = true` and clears `isStunned` at the turn boundary. If **all** of the incoming player's living characters were stunned, that player was handed a turn with nothing to do, and the server never advanced it automatically, forcing a manual `PUT phantasm/GameSession/endturn` call.

This change makes the server refuse to deal a dead turn:

- Extracted the shared `AdvanceTurn` → `ProcessTurnStartEffects` → `CheckVictoryCondition` block into a new private helper `AdvanceTurnAndProcess`, now used by both `TryAdvanceTurn` (Move/Attack/CastSpell paths) and `EndTurnAsync`.
- After start-of-turn effects run, if the incoming player has **no living character able to act**, the server logs an automatic `EndTurn` action (for traceability) and advances again.

## Why it's safe from infinite loops

If **both** players are fully incapacitated, the skip loop is bounded two independent ways:

1. It stops as soon as control returns to the player the boundary started from.
2. It caps at one iteration per distinct player regardless.

Since stun is a one-turn effect, the both-sides-stunned case settles back on the original player and resolves cleanly on the next action.

## Tests

New unit tests in `RPG-dotnet.Tests/Services/GameSessionServiceTurnEngineTests.cs` (EF InMemory provider, stubbed SignalR hub), driving the real `EndTurnAsync`:

- **Single stunned survivor auto-skips** — control returns to the acting player, stun consumed, `EndTurn` logged for the skipped character.
- **Both sides stunned does not loop forever** — call terminates, session stays `ACTIVE`, `EndTurn` log count is bounded.
- **Poison still ticks on skipped turns** — a stunned + poisoned character takes one poison tick (100 → 95, stacks 2 → 1) even though its turn is auto-skipped.

`dotnet test`: 5 passed, 0 failed (3 new + 2 pre-existing), no new warnings.

## Reviewer notes

- Behaviour boundary: when both players are stunned in the same round, play settles back on the original player rather than chasing a playable turn across rounds. This is the safe termination point; the frontend banner still covers that residual case.
- `.idea/` IDE files present in the working tree were intentionally left uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)